### PR TITLE
Make webpages mobile friendly

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta property="og:title" content="Agent Display">
     <meta property="og:description" content="Interactive agent communication interface">
     <meta property="og:type" content="website">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Agent Display</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.6.1/socket.io.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -48,6 +49,21 @@
     .messages-container::-webkit-scrollbar-thumb {
         background-color: #CBD5E0;
         border-radius: 4px;
+    }
+
+    @media (max-width: 768px) {
+        .grid-cols-1 {
+            grid-template-columns: 1fr;
+        }
+        .col-span-3 {
+            grid-column: span 1 / span 1;
+        }
+        .h-[500px] {
+            height: auto;
+        }
+        .h-[150px] {
+            height: auto;
+        }
     }
 </style>
 </head>

--- a/templates/select_prompt.html
+++ b/templates/select_prompt.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Select Prompt</title>
   <style>
     :root {
@@ -176,6 +177,22 @@
     @keyframes fadeIn {
       from { opacity: 0; transform: translateY(-10px); }
       to { opacity: 1; transform: translateY(0); }
+    }
+
+    @media (max-width: 768px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .prompt-grid {
+        grid-template-columns: 1fr;
+      }
+      .preview-panel {
+        position: static;
+        top: auto;
+      }
+      .preview-content {
+        max-height: none;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
Add mobile-friendly adjustments to `index.html` and `select_prompt.html`.

* **index.html**
  - Add meta viewport tag for proper scaling on mobile devices.
  - Add CSS media queries to adjust layout for smaller screens, including grid columns and element heights.

* **select_prompt.html**
  - Add meta viewport tag for proper scaling on mobile devices.
  - Add CSS media queries to adjust layout for smaller screens, including grid columns and element positioning.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sambosis/Slaze/pull/1?shareId=5fffd24a-8e51-4810-b1fc-48988be99304).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced responsive design with improvements for mobile devices.
	- Adjusted layout and grid configurations to smoothly transition to a single-column design on smaller screens.
	- Applied minor formatting updates to ensure a cleaner page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->