### PR TITLE
Explore using FastAPI instead of Flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,7 @@ distro==1.9.0
 executing==2.2.0
 Farama-Notifications==0.0.4
 filelock==3.17.0
-Flask==3.1.0
-Flask-SocketIO==5.5.1
-fonttools==4.56.0
+fastapi==0.95.1
 fsspec==2025.2.0
 ftfy==6.3.1
 gevent==24.11.1
@@ -86,6 +84,7 @@ tqdm==4.67.1
 typing_extensions==4.12.2
 tzdata==2025.1
 urllib3==2.3.0
+uvicorn==0.22.0
 waitress==3.0.2
 wcwidth==0.2.13
 Werkzeug==3.1.3

--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
 import asyncio
-import subprocess
+import uvicorn
 import webbrowser
 import time
 from utils.agent_display_web_with_prompt import create_app
@@ -12,7 +12,7 @@ asyncio.set_event_loop(loop)
 app = create_app(loop)
 
 # Start the server
-server_process = subprocess.Popen(["./.venv/Scripts/python", "serve.py"])
+server_process = asyncio.create_task(uvicorn.run(app, host="0.0.0.0", port=5001))
 
 # Wait a moment for the server to start
 time.sleep(2)
@@ -26,4 +26,4 @@ try:
         time.sleep(1)
 except KeyboardInterrupt:
     print("Shutting down...")
-    server_process.terminate()
+    server_process.cancel()

--- a/serve.py
+++ b/serve.py
@@ -9,5 +9,5 @@ asyncio.set_event_loop(loop)
 app = create_app(loop)
 
 if __name__ == '__main__':
-    from waitress import serve
-    serve(app, host='0.0.0.0', port=5001, threads=16)
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=5001)


### PR DESCRIPTION
Update the project to use FastAPI instead of Flask.

* **requirements.txt**
  - Add `fastapi` and `uvicorn` dependencies.
  - Remove `Flask` and `Flask-SocketIO` dependencies.

* **serve.py**
  - Replace `gunicorn` with `uvicorn` to serve the FastAPI app.

* **run.py**
  - Replace subprocess call to `serve.py` with `uvicorn.run` to start the server.

* **utils/agent_display_web_with_prompt.py**
  - Replace Flask imports and app initialization with FastAPI equivalents.
  - Convert Flask routes to FastAPI routes.
  - Update WebSocket handling to use FastAPI's WebSocket support.

* **utils/agent_display_web.py**
  - Replace Flask imports and app initialization with FastAPI equivalents.
  - Convert Flask routes to FastAPI routes.
  - Update WebSocket handling to use FastAPI's WebSocket support.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sambosis/Slaze/pull/3?shareId=6b722582-8242-4c17-b699-59137f1b91e6).