### PR TITLE
Fix tool formatting for OpenAI API

### DIFF
--- a/tools/create_picture.py
+++ b/tools/create_picture.py
@@ -25,37 +25,38 @@ class PictureGenerationTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         ic(f"PictureGenerationTool.to_params called with api_type: {self.api_type}")
-        # Use the format that has worked in the past
         params = {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": [cmd.value for cmd in PictureCommand],
-                        "description": "Command to execute: create",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": [cmd.value for cmd in PictureCommand],
+                            "description": "Command to execute: create",
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "Text description of the image to generate",
+                        },
+                        "output_path": {
+                            "type": "string",
+                            "description": "Path where the generated image will be saved",
+                        },
+                        "width": {
+                            "type": "integer",
+                            "description": "Width to resize the image (required)",
+                        },
+                        "height": {
+                            "type": "integer",
+                            "description": "Height to resize the image (required)",
+                        },
                     },
-                    "prompt": {
-                        "type": "string",
-                        "description": "Text description of the image to generate",
-                    },
-                    "output_path": {
-                        "type": "string",
-                        "description": "Path where the generated image will be saved",
-                    },
-                    "width": {
-                        "type": "integer",
-                        "description": "Width to resize the image (required)",
-                    },
-                    "height": {
-                        "type": "integer",
-                        "description": "Height to resize the image (required)",
-                    },
+                    "required": ["command", "prompt", "width", "height"],
                 },
-                "required": ["command", "prompt", "width", "height"],
             },
         }
         ic(f"PictureGenerationTool params: {params}")

--- a/tools/docker_edit.py
+++ b/tools/docker_edit.py
@@ -56,47 +56,47 @@ class DockerEditTool(BaseAnthropicTool):
         ##ll.info(f"Docker available: {self._docker_available}")
 
     def to_params(self) -> dict:
-        # ll.debug(f"DockerEditTool.to_params called with api_type: {self.api_type}")
-        # For custom tools, provide a detailed input schema
         params = {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": [cmd for cmd in get_args(Command)],
-                        "description": "Command to execute. Options: view, create, str_replace, insert, undo_edit",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": [cmd for cmd in get_args(Command)],
+                            "description": "Command to execute. Options: view, create, str_replace, insert, undo_edit",
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Path to the file to operate on",
+                        },
+                        "file_text": {
+                            "type": "string",
+                            "description": "Content to write to the file (required for create command)",
+                        },
+                        "view_range": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "description": "Range of lines to view [start_line, end_line] (optional for view command)",
+                        },
+                        "old_str": {
+                            "type": "string",
+                            "description": "String to be replaced (required for str_replace command)",
+                        },
+                        "new_str": {
+                            "type": "string",
+                            "description": "Replacement string (required for str_replace and insert commands)",
+                        },
+                        "insert_line": {
+                            "type": "integer",
+                            "description": "Line number where to insert text (required for insert command)",
+                        },
                     },
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file to operate on",
-                    },
-                    "file_text": {
-                        "type": "string",
-                        "description": "Content to write to the file (required for create command)",
-                    },
-                    "view_range": {
-                        "type": "array",
-                        "items": {"type": "integer"},
-                        "description": "Range of lines to view [start_line, end_line] (optional for view command)",
-                    },
-                    "old_str": {
-                        "type": "string",
-                        "description": "String to be replaced (required for str_replace command)",
-                    },
-                    "new_str": {
-                        "type": "string",
-                        "description": "Replacement string (required for str_replace and insert commands)",
-                    },
-                    "insert_line": {
-                        "type": "integer",
-                        "description": "Line number where to insert text (required for insert command)",
-                    },
+                    "required": ["command", "path"],
                 },
-                "required": ["command", "path"],
             },
         }
         ic(f"DockerEditTool params: {params}")

--- a/tools/envsetup.py
+++ b/tools/envsetup.py
@@ -55,45 +55,44 @@ class ProjectSetupTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         """Convert the tool to a parameters dictionary for the API."""
-        # ic(f"ProjectSetupTool.to_params called with api_type: {self.api_type}")
-        # Use the format that has worked in the past
         params = {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": [cmd.value for cmd in ProjectCommand],
-                        "description": "Command to execute",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": [cmd.value for cmd in ProjectCommand],
+                            "description": "Command to execute",
+                        },
+                        "project_path": {
+                            "type": "string",
+                            "description": "Path to the project directory",
+                        },
+                        "environment": {
+                            "type": "string",
+                            "enum": ["python", "node"],
+                            "description": "Environment type (python or node)",
+                            "default": "python",
+                        },
+                        "packages": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "List of packages to install, This can be used during the setup_project command or the add_dependencies command. this should be a list of strings with each package in quotes and separated by commas, with the list enclosed in square brackets. Example: ['package1', 'package2', 'package3']",
+                        },
+                        "entry_filename": {
+                            "type": "string",
+                            "description": "Name of the entry point file to run",
+                            "default": "app.py",
+                        },
                     },
-                    "project_path": {
-                        "type": "string",
-                        "description": "Path to the project directory",
-                    },
-                    "environment": {
-                        "type": "string",
-                        "enum": ["python", "node"],
-                        "description": "Environment type (python or node)",
-                        "default": "python",
-                    },
-                    "packages": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "List of packages to install, This can be used during the setup_project command or the add_dependencies command. this should be a list of strings with each package in quotes and separated by commas, with the list enclosed in square brackets. Example: ['package1', 'package2', 'package3']",
-                    },
-                    "entry_filename": {
-                        "type": "string",
-                        "description": "Name of the entry point file to run",
-                        "default": "app.py",
-                    },
+                    "required": ["command", "project_path"],
                 },
-                "required": ["command", "project_path"],
             },
         }
-        # ic(f"ProjectSetupTool params: {params}")
         return params
 
     def get_docker_path(self, project_path: Path) -> str:

--- a/tools/expert.py
+++ b/tools/expert.py
@@ -22,23 +22,25 @@ class GetExpertOpinionTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         return {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": ["get_opinion"],
-                        "description": "The command to get an expert opinion.",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": ["get_opinion"],
+                            "description": "The command to get an expert opinion.",
+                        },
+                        "problem_description": {
+                            "type": "string",
+                            "description": "A detailed description of the problem and everything that has been tried so far. If for programming, include the code that has been tried.",
+                        },
                     },
-                    "problem_description": {
-                        "type": "string",
-                        "description": "A detailed description of the problem and everything that has been tried so far. If for programming, include the code that has been tried.",
-                    },
+                    "required": ["command", "problem_description"],
                 },
-                "required": ["command", "problem_description"],
             },
         }
 

--- a/tools/get_serp.py
+++ b/tools/get_serp.py
@@ -20,26 +20,28 @@ class GoogleSearchTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         return {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query to execute",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query to execute",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "Optional location to geo-target results (e.g. 'Baltimore, Maryland, United States')",
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Optional language code (e.g. 'en')",
+                        },
                     },
-                    "location": {
-                        "type": "string",
-                        "description": "Optional location to geo-target results (e.g. 'Baltimore, Maryland, United States')",
-                    },
-                    "language": {
-                        "type": "string",
-                        "description": "Optional language code (e.g. 'en')",
-                    },
+                    "required": ["query"],
                 },
-                "required": ["query"],
             },
         }
 

--- a/tools/gotourl_reports.py
+++ b/tools/gotourl_reports.py
@@ -54,23 +54,25 @@ class GoToURLReportsTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         return {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {  # Use parameters instead of custom.input_schema
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": ["list_reports", "run_report"],
-                        "description": "The command to execute. Either 'list_reports' to list all reports or 'run_report' to execute a specific report.",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": ["list_reports", "run_report"],
+                            "description": "The command to execute. Either 'list_reports' to list all reports or 'run_report' to execute a specific report.",
+                        },
+                        "report_name": {
+                            "type": "string",
+                            "description": "The name of the report to run. Required if command is 'run_report'.",
+                        },
                     },
-                    "report_name": {
-                        "type": "string",
-                        "description": "The name of the report to run. Required if command is 'run_report'.",
-                    },
+                    "required": ["command"],
                 },
-                "required": ["command"],
             },
         }
 

--- a/tools/playwright.py
+++ b/tools/playwright.py
@@ -78,61 +78,61 @@ class WebNavigatorTool:
             self.page = None
 
     def to_params(self) -> dict:
-        """
-        Defines the parameters for the tool, specifying the input schema.
-        """
+        """Defines the parameters for the tool, specifying the input schema."""
         return {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string",
-                        "description": "The URL to perform the action on.",
-                    },
-                    "action": {
-                        "type": "string",
-                        "enum": [
-                            "read",
-                            "navigate",
-                            "download",
-                            "fill_form",
-                            "extract_data",
-                            "click_element",
-                        ],
-                        "description": "The action to perform.",
-                    },
-                    "params": {
-                        "type": "object",
-                        "description": "Additional parameters required for the action.",
-                        "properties": {
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path to save the downloaded file (required for 'download' action).",
-                            },
-                            "form_selector": {
-                                "type": "string",
-                                "description": "CSS selector for the form to fill (required for 'fill_form' action).",
-                            },
-                            "form_data": {
-                                "type": "object",
-                                "additionalProperties": {"type": "string"},
-                                "description": "Data to fill into the form fields.",
-                            },
-                            "data_selector": {
-                                "type": "string",
-                                "description": "CSS selector for data extraction (required for 'extract_data' action).",
-                            },
-                            "element_selector": {
-                                "type": "string",
-                                "description": "CSS selector of the element to click (required for 'click_element' action).",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "The URL to perform the action on.",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "read",
+                                "navigate",
+                                "download",
+                                "fill_form",
+                                "extract_data",
+                                "click_element",
+                            ],
+                            "description": "The action to perform.",
+                        },
+                        "params": {
+                            "type": "object",
+                            "description": "Additional parameters required for the action.",
+                            "properties": {
+                                "file_path": {
+                                    "type": "string",
+                                    "description": "Path to save the downloaded file (required for 'download' action).",
+                                },
+                                "form_selector": {
+                                    "type": "string",
+                                    "description": "CSS selector for the form to fill (required for 'fill_form' action).",
+                                },
+                                "form_data": {
+                                    "type": "object",
+                                    "additionalProperties": {"type": "string"},
+                                    "description": "Data to fill into the form fields.",
+                                },
+                                "data_selector": {
+                                    "type": "string",
+                                    "description": "CSS selector for data extraction (required for 'extract_data' action).",
+                                },
+                                "element_selector": {
+                                    "type": "string",
+                                    "description": "CSS selector of the element to click (required for 'click_element' action).",
+                                },
                             },
                         },
                     },
+                    "required": ["url", "action"],
                 },
-                "required": ["url", "action"],
             },
         }
 

--- a/tools/windows_navigation.py
+++ b/tools/windows_navigation.py
@@ -52,14 +52,15 @@ class WindowsNavigationTool:
     def to_params(self) -> dict:
         """Define the parameters for the tool."""
         return {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
                         "enum": [
                             # Window Management
                             "switch_window",
@@ -96,18 +97,19 @@ class WindowsNavigationTool:
                             "toggle_magnifier",
                         ],
                         "description": "The Windows action to perform",
+                        },
+                        "modifier": {
+                            "type": "string",
+                            "enum": ["ctrl", "alt", "shift", "win"],
+                            "description": "Optional modifier key(s)",
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "Optional target for the action (e.g., window title)",
+                        },
                     },
-                    "modifier": {
-                        "type": "string",
-                        "enum": ["ctrl", "alt", "shift", "win"],
-                        "description": "Optional modifier key(s)",
-                    },
-                    "target": {
-                        "type": "string",
-                        "description": "Optional target for the action (e.g., window title)",
-                    },
+                    "required": ["action"],
                 },
-                "required": ["action"],
             },
         }
 

--- a/tools/write_code.py
+++ b/tools/write_code.py
@@ -125,56 +125,57 @@ class WriteCodeTool(BaseAnthropicTool):
         ic(f"Docker available: {self._docker_available}")
 
     def to_params(self) -> dict:
-        # ... (your existing to_params method - no changes needed here from provided snippet)
         ic(f"WriteCodeTool.to_params called with api_type: {self.api_type}")
         params = {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": [CodeCommand.WRITE_CODEBASE.value],
-                        "description": "Command to perform. Only 'write_codebase' is supported.",
-                    },
-                    "files": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "filename": {
-                                    "type": "string",
-                                    "description": "Name/path of the file relative to the project path.",
-                                },
-                                "code_description": {
-                                    "type": "string",
-                                    "description": "Detailed description of the code for this file.",
-                                },
-                                "external_imports": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "List of external libraries/packages required specifically for this file.",
-                                    "default": [],
-                                },
-                                "internal_imports": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "List of internal modules/files within the codebase imported specifically by this file.",
-                                    "default": [],
-                                },
-                            },
-                            "required": ["filename", "code_description"],
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": [CodeCommand.WRITE_CODEBASE.value],
+                            "description": "Command to perform. Only 'write_codebase' is supported.",
                         },
-                        "description": "List of files to generate, each with a filename, description, and optional specific imports.",
+                        "files": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "filename": {
+                                        "type": "string",
+                                        "description": "Name/path of the file relative to the project path.",
+                                    },
+                                    "code_description": {
+                                        "type": "string",
+                                        "description": "Detailed description of the code for this file.",
+                                    },
+                                    "external_imports": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                        "description": "List of external libraries/packages required specifically for this file.",
+                                        "default": [],
+                                    },
+                                    "internal_imports": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                        "description": "List of internal modules/files within the codebase imported specifically by this file.",
+                                        "default": [],
+                                    },
+                                },
+                                "required": ["filename", "code_description"],
+                            },
+                            "description": "List of files to generate, each with a filename, description, and optional specific imports.",
+                        },
+                        "project_path": {
+                            "type": "string",
+                            "description": "Path to the project directory (can be Docker-style or just project name). The actual write path will be resolved relative to the configured REPO_DIR on the host.",
+                        },
                     },
-                    "project_path": {
-                        "type": "string",
-                        "description": "Path to the project directory (can be Docker-style or just project name). The actual write path will be resolved relative to the configured REPO_DIR on the host.",
-                    },
+                    "required": ["command", "files", "project_path"],
                 },
-                "required": ["command", "files", "project_path"],
             },
         }
         ic(f"WriteCodeTool params: {params}")

--- a/tools/write_codeBU.py
+++ b/tools/write_codeBU.py
@@ -193,33 +193,34 @@ class WriteCodeTool(BaseAnthropicTool):
 
     def to_params(self) -> dict:
         ic(f"WriteCodeTool.to_params called with api_type: {self.api_type}")
-        # Use the format that has worked in the past
         params = {
-            "name": self.name,
-            "description": self.description,
-            "type": self.api_type,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "enum": [cmd.value for cmd in CodeCommand],
-                        "description": "Command to perform. Options: write_code_to_file, write_and_exec, write_code_multiple_files, get_all_current_code, get_revised_version",
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": [cmd.value for cmd in CodeCommand],
+                            "description": "Command to perform. Options: write_code_to_file, write_and_exec, write_code_multiple_files, get_all_current_code, get_revised_version",
+                        },
+                        "code_description": {
+                            "type": "string",
+                            "description": "Description for single file code generation. This should be a very detailed description of the code to be created. Include any assumption and specific details including necessary imports and how to interact with other aspects of the code.",
+                        },
+                        "project_path": {
+                            "type": "string",
+                            "description": "Path to the project directory.",
+                        },
+                        "python_filename": {
+                            "type": "string",
+                            "description": "Filename for write_code_to_file command.",
+                        },
                     },
-                    "code_description": {
-                        "type": "string",
-                        "description": "Description for single file code generation. This should be a very detailed description of the code to be created. Include any assumption and specific details including necessary imports and how to interact with other aspects of the code.",
-                    },
-                    "project_path": {
-                        "type": "string",
-                        "description": "Path to the project directory.",
-                    },
-                    "python_filename": {
-                        "type": "string",
-                        "description": "Filename for write_code_to_file command.",
-                    },
+                    "required": ["command"],
                 },
-                "required": ["command"],
             },
         }
         ic(f"WriteCodeTool params: {params}")


### PR DESCRIPTION
## Summary
- update tool definitions to conform to OpenAI `tools` format
- ensure tools return `function` blocks with parameter schemas
- keep test suite passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f90bf763883319b06473f2eacfe85

## Summary by Sourcery

Update all custom tools to produce OpenAI-compatible function definitions by replacing the legacy input_schema format with a top-level "type": "function" block and nested "function" object containing name, description, parameters, and required fields.

Enhancements:
- Standardize all tool to_params methods to emit OpenAI function definitions instead of the old input_schema structure
- Nest schema details (properties and required lists) under a new "function" object for each tool
- Add explicit required field lists to each tool’s parameter schema to enforce mandatory inputs
- Preserve existing behavior and keep the test suite passing without altering test code