### PR TITLE
Fix: Conditionally include tool_calls in assistant messages

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -248,14 +248,13 @@ class Agent:
             return True
 
         msg = response.choices[0].message
-        self.messages.append(
-            {
-                "role": "assistant",
-                "content": msg.content or "",
-                "tool_calls": [tc.to_dict() for tc in (msg.tool_calls or [])],
-            }
-        )
-
+        assistant_message = {
+            "role": "assistant",
+            "content": msg.content or "",
+        }
+        if msg.tool_calls:
+            assistant_message["tool_calls"] = [tc.to_dict() for tc in msg.tool_calls]
+        self.messages.append(assistant_message)
 
         if msg.tool_calls:
             for tc in msg.tool_calls:


### PR DESCRIPTION
The LLM API (specifically Azure) raises an error if the 'tool_calls' field in an assistant message is an empty array. This change modifies my process to only include the 'tool_calls' key in the assistant's message if I actually decide to make tool calls.

This prevents the error: "Invalid 'messages[X].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead."

## Summary by Sourcery

Bug Fixes:
- Only include the 'tool_calls' field in assistant messages when non-empty to prevent Azure LLM API errors