### PR TITLE
Fix tool_calls empty array

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -248,13 +248,10 @@ class Agent:
             return True
 
         msg = response.choices[0].message
-        self.messages.append(
-            {
-                "role": "assistant",
-                "content": msg.content or "",
-                "tool_calls": [tc.to_dict() for tc in (msg.tool_calls or [])],
-            }
-        )
+        assistant_msg = {"role": "assistant", "content": msg.content or ""}
+        if msg.tool_calls:
+            assistant_msg["tool_calls"] = [tc.to_dict() for tc in msg.tool_calls]
+        self.messages.append(assistant_msg)
 
 
         if msg.tool_calls:


### PR DESCRIPTION
## Summary
- avoid including an empty `tool_calls` list in assistant messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684863fb9b348331abae1562f84871ac

## Summary by Sourcery

Bug Fixes:
- Avoid including an empty `tool_calls` list in assistant messages by only adding the field when tool calls exist.