### PR TITLE
Add context logging for LLM code generation

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,7 @@ MAIN_MODEL = googlepro
 COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
 PROMPT_CACHING_BETA_FLAG = "prompt-caching-2024-07-31"
 CODE_FILE = LOGS_DIR / "code_messages.py"
+CODE_CONTEXT_FILE = LOGS_DIR / "code_context.log"
 USER_LOG_FILE = LOGS_DIR / "user_messages.log"
 ASSISTANT_LOG_FILE = LOGS_DIR / "assistant_messages.log"
 TOOL_LOG_FILE = LOGS_DIR / "tool_messages.log"
@@ -73,6 +74,7 @@ def write_constants_to_file():
         "MESSAGES_FILE": str(MESSAGES_FILE),
         "ICECREAM_OUTPUT_FILE": str(ICECREAM_OUTPUT_FILE),
         "CODE_FILE": str(CODE_FILE),
+        "CODE_CONTEXT_FILE": str(CODE_CONTEXT_FILE),
         "TASK": "NOT YET CREATED",
     }
     with open(CACHE_DIR / "constants.json", "w") as f:


### PR DESCRIPTION
## Summary
- log prepared messages for code and skeleton generation in `WriteCodeTool`
- store context in `logs/code_context.log`
- expose new constant `CODE_CONTEXT_FILE`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848761722ec83319ea699c57b79e97f