### PR TITLE
Fix EditTool path handling

### DIFF
--- a/tools/edit.py
+++ b/tools/edit.py
@@ -132,8 +132,8 @@ class EditTool(BaseTool):
                     "user", f"EditTool Executing Command: {command} on path: {path}"
                 )
 
-            # Normalize the path first
-            _path = path
+            # Normalize the path first by converting to a Path object
+            _path = Path(path)
             if command == "create":
                 if not file_text:
                     raise ToolError(


### PR DESCRIPTION
## Summary
- convert string file paths to `Path` objects in EditTool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bf9bd6888331a83c98105f62b763