### PR TITLE
Fix console logger encoding

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 from typing import Optional, Any
 import logging
 import logging.handlers
+import sys
 from cycler import V
 
 global PROJECT_DIR
@@ -13,6 +14,11 @@ PROJECT_DIR = None
 
 # Load environment variables from .env file
 load_dotenv()
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
 
 # Logging constants
 LOG_LEVEL_CONSOLE = "INFO"


### PR DESCRIPTION
## Summary
- initialize stdout with UTF-8 encoding
- keep StreamHandler but allow console to handle non-ASCII

## Testing
- `python - <<'PY'
import logging
import config
logger = logging.getLogger('test')
logger.info('line with special char │ test')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684997c7a20c8331968fb6eb45a0dc26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved handling of UTF-8 encoding for standard output to enhance compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->