### PR TITLE
Fix retry predicate signature

### DIFF
--- a/tools/write_code.py
+++ b/tools/write_code.py
@@ -49,17 +49,8 @@ MODEL_STRING = googlepro  # Default model string, can be overridden in config
 logger = logging.getLogger(__name__)
 
 # --- Retry Predicate Function ---
-def should_retry_llm_call(retry_state: RetryCallState) -> bool:
-    """
-    Determines if a retry should occur based on the raised exception.
-    Accesses the exception from retry_state.outcome.exception().
-    """
-    if not retry_state.outcome:  # Should not happen if called after an attempt
-        return False
-
-    exception = retry_state.outcome.exception()
-    if not exception:  # No exception, successful outcome
-        return False
+def should_retry_llm_call(exception: Exception) -> bool:
+    """Return True if the exception warrants a retry."""
 
     # Always retry on our custom LLMResponseError
     if isinstance(exception, LLMResponseError):


### PR DESCRIPTION
## Summary
- fix retry logic signature used by tenacity decorators

## Testing
- `python -m py_compile tools/write_code.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849a50e7e4c83318f8f6417cc0ddfba