### PR TITLE
Fix: Configure logging to use UTF-8 encoding

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,7 +11,20 @@ from agent import Agent
 
 # Docker and web server related functions have been removed.
 
-logger = logging.getLogger(__name__)
+import sys # Add this import
+
+# Configure root logger for UTF-8
+root_logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+# Explicitly set encoding to UTF-8 for the handler
+handler.stream.reconfigure(encoding='utf-8') # type: ignore
+root_logger.addHandler(handler)
+root_logger.setLevel(logging.INFO)
+
+# Test logger with a unicode character
+logger = logging.getLogger(__name__) # This line should remain to keep the local logger
+logger.info("Logging configured. Testing with Unicode: │")
 
 # ----------------  The main Agent Loop ----------------
 async def sampling_loop(


### PR DESCRIPTION
This change addresses a UnicodeEncodeError that occurred when logging messages containing characters not supported by the default cp1252 encoding on Windows.

The root logger in `run.py` is now explicitly configured with a StreamHandler that uses `sys.stdout` and UTF-8 encoding. This ensures that Unicode characters, such as box drawing characters (`│`), can be logged without error.

A test log message containing a Unicode character has been added to `run.py` to verify the fix.