### PR TITLE
Redirect logs to file

### DIFF
--- a/config.py
+++ b/config.py
@@ -366,11 +366,7 @@ def setup_logging():
 
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s - %(funcName)s - %(lineno)d - %(message)s')
 
-    # Console Handler
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(getattr(logging, _get_constant_for_logging_setup("LOG_LEVEL_CONSOLE").upper(), logging.INFO))
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+
 
     # File Handler
     # Use _get_constant_for_logging_setup for LOGS_DIR during setup

--- a/run.py
+++ b/run.py
@@ -13,13 +13,8 @@ from agent import Agent
 
 import sys # Add this import
 
-# Configure root logger for UTF-8
+# Configure root logger for UTF-8 and file output only
 root_logger = logging.getLogger()
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-# Explicitly set encoding to UTF-8 for the handler
-handler.stream.reconfigure(encoding='utf-8') # type: ignore
-root_logger.addHandler(handler)
 root_logger.setLevel(logging.INFO)
 
 # Test logger with a unicode character


### PR DESCRIPTION
## Summary
- remove console logging setup
- default to file logging only

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684af07026c88331900f53a3b3717814

## Summary by Sourcery

Remove console-based logging and default to file-only logging with UTF-8 encoding

Enhancements:
- Remove console/stream handler setup from run.py and config.py
- Ensure root logger is configured for UTF-8 and file output only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed console logging output; logs will now be written only to files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->