### PR TITLE
Refactor: Direct all logs to file, disable console logging

### DIFF
--- a/config.py
+++ b/config.py
@@ -369,10 +369,10 @@ def setup_logging():
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s - %(funcName)s - %(lineno)d - %(message)s')
 
     # Console Handler
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(getattr(logging, _get_constant_for_logging_setup("LOG_LEVEL_CONSOLE").upper(), logging.INFO))
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    # console_handler = logging.StreamHandler()
+    # console_handler.setLevel(getattr(logging, _get_constant_for_logging_setup("LOG_LEVEL_CONSOLE").upper(), logging.INFO))
+    # console_handler.setFormatter(formatter)
+    # logger.addHandler(console_handler)
 
     # File Handler
     # Use _get_constant_for_logging_setup for LOGS_DIR during setup


### PR DESCRIPTION
This change modifies the logging configuration to ensure that all application logs are written to a file and no logs are displayed on the console.

- In `config.py`, the StreamHandler (console logger) has been removed from the logging setup.
- The RotatingFileHandler remains active, with `LOG_LEVEL_FILE` set to 'DEBUG' to capture all necessary log details in `logs/app.log`.

## Summary by Sourcery

Refactor logging configuration to write all application logs exclusively to a file and disable console output

Enhancements:
- Comment out the StreamHandler setup to disable console logging
- Retain the RotatingFileHandler at DEBUG level to capture all log details in logs/app.log