### PR TITLE
Fix BashTool to honor PROJECT_DIR

### DIFF
--- a/tools/bash.py
+++ b/tools/bash.py
@@ -66,7 +66,9 @@ class BashTool(BaseTool):
                 self.display.add_message("user", f"Executing command: {command}")
 
             try:
-                # Execute the command locally
+                # Execute the command locally relative to PROJECT_DIR if set
+                project_dir = get_constant("PROJECT_DIR")
+                cwd = str(project_dir) if project_dir else None
                 result = subprocess.run(
                     command,
                     shell=True,
@@ -75,6 +77,7 @@ class BashTool(BaseTool):
                     encoding="utf-8",
                     errors="replace",
                     check=False,
+                    cwd=cwd,
                 )
                 output = result.stdout
                 error = result.stderr


### PR DESCRIPTION
## Summary
- ensure BashTool executes commands relative to `PROJECT_DIR`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6f9b81408331b6928a7693036b36

## Summary by Sourcery

Ensure BashTool executes shell commands relative to the configured PROJECT_DIR.

Bug Fixes:
- Fix BashTool to honor PROJECT_DIR when executing commands by setting the working directory.

Enhancements:
- Retrieve PROJECT_DIR constant and pass it as the cwd parameter to subprocess.run.