### PR TITLE
Fix: Pass slicer_config and physics_config to DesignEnvironment

### DIFF
--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -34,6 +34,7 @@ except ImportError:
         "Please install it with: pip install stable-baselines3[extra]"
     )
 
+from stls.src.lspo_3d.config import PRUSA_SLICER_PATH, OPENSCAD_PATH
 from lspo_3d.environment import DesignEnvironment
 from lspo_3d.models.agent import AgentPolicy
 from lspo_3d.models.generator import CadQueryGenerator
@@ -115,10 +116,22 @@ def train_agent(config: argparse.Namespace) -> None:
         'print_time_penalty': -0.01,       # Per second
         'filament_penalty': -0.5,          # Per mm^3
     }
+
+    slicer_config = {
+        "slicer_path": PRUSA_SLICER_PATH,
+        "config_path": None,
+    }
+
+    physics_config = {
+        "duration_steps": 2400,
+        "load_config": {},
+    }
     
     print("Initializing DesignEnvironment...")
     env = DesignEnvironment(
         generator=generator,
+        slicer_config=slicer_config,
+        physics_config=physics_config,
         num_motifs=config.num_motifs,
         design_prompt="Design a vertical stand for a standard smartphone.",
         max_steps=config.max_episode_steps,

--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -34,7 +34,7 @@ except ImportError:
         "Please install it with: pip install stable-baselines3[extra]"
     )
 
-from stls.src.lspo_3d.config import PRUSA_SLICER_PATH, OPENSCAD_PATH
+from stls.src.lspo_3d.config import PRUSA_SLICER_PATH
 from lspo_3d.environment import DesignEnvironment
 from lspo_3d.models.agent import AgentPolicy
 from lspo_3d.models.generator import CadQueryGenerator


### PR DESCRIPTION
The DesignEnvironment constructor requires `slicer_config` and `physics_config` arguments, which were not being passed during its instantiation in `train_agent.py`.

This change defines these two configuration dictionaries in `stls/lspo_3d/train_agent.py` using default values and paths imported from `stls.src.lspo_3d.config`, and passes them to the DesignEnvironment constructor, resolving the TypeError.

## Summary by Sourcery

Bug Fixes:
- Define and pass default slicer_config and physics_config dictionaries to the DesignEnvironment constructor in train_agent to resolve missing argument errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment initialization to include new configuration options for slicer and physics simulation. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->