### PR TITLE
Fix import path for CSGGenerator

### DIFF
--- a/stls/lspo_3d/environment.py
+++ b/stls/lspo_3d/environment.py
@@ -20,9 +20,9 @@ import numpy as np
 
 # --- Internal Imports ---
 from lspo_3d.models.generator import CadQueryGenerator
-from src.lspo_3d.oracles.csg_executor import execute_cad_script
-from src.lspo_3d.oracles.physics_verifier import verify_stability
-from src.lspo_3d.oracles.slicer_verifier import get_slicer_metrics, SlicerMetrics
+from lspo_3d.oracles.csg_executor import execute_cad_script
+from lspo_3d.oracles.physics_verifier import verify_stability
+from lspo_3d.oracles.slicer_verifier import get_slicer_metrics, SlicerMetrics
 
 # Set up a logger for this module
 logger = logging.getLogger(__name__)

--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -35,8 +35,8 @@ except ImportError:
     )
 
 from src.lspo_3d.config import PRUSA_SLICER_PATH
-from src.lspo_3d.environment import DesignEnvironment
-from src.lspo_3d.models.agent import AgentPolicy
+from lspo_3d.environment import DesignEnvironment
+from lspo_3d.models.agent import AgentPolicy
 from lspo_3d.models.generator import CadQueryGenerator
 
 

--- a/stls/lspo_3d/train_motifs.py
+++ b/stls/lspo_3d/train_motifs.py
@@ -34,7 +34,7 @@ from tqdm import tqdm
 # Internal project imports
 # Assuming that processor.py has been run and has outputted text files with CSG traces.
 # from src.lspo_3d.data.processor import process_raw_models # Not used; we load pre-processed traces.
-from src.lspo_3d.models.motif_encoder import MotifEncoder
+from lspo_3d.models.motif_encoder import MotifEncoder
 
 # Set up basic logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/stls/scripts/02_pretrain_generator.py
+++ b/stls/scripts/02_pretrain_generator.py
@@ -20,7 +20,9 @@ from src.lspo_3d import config
 from src.lspo_3d.data.dataset import CSGDataset
 from src.lspo_3d.data.tokenizer import CSGTokenizer
 from src.lspo_3d.models.encoder import CSGEncoder
-from lspo_3d.models.generator import CSGGenerator
+# Import the experimental CSGGenerator from the src package. The
+# top-level `lspo_3d` package only exposes the CadQuery generator.
+from src.lspo_3d.models.generator import CSGGenerator
 from src.lspo_3d.utils import setup_logging
 
 # Setup basic logging

--- a/stls/scripts/03_run_lspo_training.py
+++ b/stls/scripts/03_run_lspo_training.py
@@ -11,7 +11,9 @@ from stable_baselines3.common.vec_env import DummyVecEnv
 # Internal project imports
 from src.lspo_3d import config
 from src.lspo_3d import utils
-from lspo_3d.models.generator import CSGGenerator
+# Import the experimental CSGGenerator from the src package. The
+# top-level `lspo_3d` package only provides the CadQuery generator.
+from src.lspo_3d.models.generator import CSGGenerator
 from src.lspo_3d.oracles.slicer import SlicerOracle
 from src.lspo_3d.oracles.physics import PhysicsOracle
 from src.lspo_3d.rl.environment import DesignEnvironment

--- a/stls/src/lspo_3d/rl/environment.py
+++ b/stls/src/lspo_3d/rl/environment.py
@@ -7,7 +7,10 @@ import numpy as np
 from gym import spaces
 
 from src.lspo_3d import config
-from lspo_3d.models.generator import CSGGenerator
+# Use the CSGGenerator defined in the src package. Importing from the
+# top-level `lspo_3d` package would fail because that package only
+# exposes the `CadQueryGenerator` used in a different pipeline.
+from src.lspo_3d.models.generator import CSGGenerator
 from src.lspo_3d.oracles.reward import calculate_reward
 
 


### PR DESCRIPTION
## Summary
- import CSGGenerator from `src.lspo_3d.models.generator` in RL environment
- update pretraining and training scripts to reference CSGGenerator from `src.lspo_3d`

## Testing
- `python test_all.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684c737804148331a2d52ff9faf84b25

## Summary by Sourcery

Fix CSGGenerator import paths across the RL environment and training scripts to reference the updated module location

Bug Fixes:
- Correct CSGGenerator import in the RL environment
- Update pretraining script to import CSGGenerator from the new path
- Update LSPO training script to import CSGGenerator from the new path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated comments to clarify import sources for experimental features.

- **Chores**
  - Adjusted import paths for experimental components to improve clarity and maintainability. No changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->