### PR TITLE
Fix TypeError in PPO instantiation

### DIFF
--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -174,6 +174,7 @@ def train_agent(config: argparse.Namespace) -> None:
         verbose=1,
         tensorboard_log=str(log_dir / "tensorboard_logs"),
         device=device,
+        use_sde=False, # Add this line
     )
 
     # --- Start Training ---


### PR DESCRIPTION
The `AgentPolicy` class was receiving an unexpected keyword argument `use_sde` from the `stable_baselines3.PPO` constructor.

This commit explicitly sets `use_sde=False` in the `PPO` constructor call within `stls/lspo_3d/train_agent.py` to prevent this argument from being passed to the custom `AgentPolicy`, which is not designed to handle it.

## Summary by Sourcery

Bug Fixes:
- Explicitly set `use_sde=False` in the PPO instantiation to avoid a TypeError in `train_agent.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where State-Dependent Exploration (SDE) was unintentionally enabled in the PPO agent configuration. SDE is now explicitly disabled during training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->