### PR TITLE
Fix policy initialization for PPO

### DIFF
--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -36,7 +36,6 @@ except ImportError:
 
 from src.lspo_3d.config import PRUSA_SLICER_PATH
 from lspo_3d.environment import DesignEnvironment
-from lspo_3d.models.agent import AgentPolicy
 from lspo_3d.models.generator import CadQueryGenerator
 
 
@@ -149,16 +148,19 @@ def train_agent(config: argparse.Namespace) -> None:
     )
 
     # --- Define PPO Policy and Hyperparameters ---
-    # `AgentPolicy` is a custom nn.Module. SB3 takes this as a policy class
-    # and `policy_kwargs` are passed to its constructor.
-    # SB3 automatically infers state_dim and action_dim from the env.
+    # Use the built-in MultiInputPolicy to handle the dictionary observation
+    # space returned by ``DesignEnvironment``. ``policy_kwargs`` configures the
+    # underlying MLP used for the actor and critic networks.
     policy_kwargs = {
-        'hidden_dim': config.hidden_dim,
+        "net_arch": [
+            dict(pi=[config.hidden_dim, config.hidden_dim],
+                 vf=[config.hidden_dim, config.hidden_dim])
+        ],
     }
 
     print("Instantiating PPO agent...")
     model = PPO(
-        policy=AgentPolicy,
+        policy="MultiInputPolicy",
         env=env,
         learning_rate=config.learning_rate,
         n_steps=config.n_steps,


### PR DESCRIPTION
## Summary
- update `train_agent.py` to use the built-in `MultiInputPolicy`
- remove unused `AgentPolicy` import

## Testing
- `python test_all.py` *(fails: Command `uv run stls/runner.py` hangs)*

------
https://chatgpt.com/codex/tasks/task_e_684c909897f08331a74141ffb48f4785

## Summary by Sourcery

Use SB3's MultiInputPolicy instead of the custom AgentPolicy in PPO training, configure policy_kwargs with net_arch for the actor and critic networks, and remove the unused AgentPolicy import

Bug Fixes:
- Fix PPO policy initialization to support dictionary observation spaces by switching to MultiInputPolicy

Enhancements:
- Update policy_kwargs to define separate actor and critic network architectures using net_arch
- Replace custom AgentPolicy with built-in MultiInputPolicy for PPO

Chores:
- Remove unused AgentPolicy import