### PR TITLE
Fix PPO policy instantiation

### DIFF
--- a/stls/lspo_3d/train_agent.py
+++ b/stls/lspo_3d/train_agent.py
@@ -36,7 +36,6 @@ except ImportError:
 
 from src.lspo_3d.config import PRUSA_SLICER_PATH
 from lspo_3d.environment import DesignEnvironment
-from lspo_3d.models.agent import AgentPolicy
 from lspo_3d.models.generator import CadQueryGenerator
 
 
@@ -149,16 +148,15 @@ def train_agent(config: argparse.Namespace) -> None:
     )
 
     # --- Define PPO Policy and Hyperparameters ---
-    # `AgentPolicy` is a custom nn.Module. SB3 takes this as a policy class
-    # and `policy_kwargs` are passed to its constructor.
-    # SB3 automatically infers state_dim and action_dim from the env.
+    # Use SB3's built-in MlpPolicy with a simple network architecture.
+    # This avoids incompatibilities with the earlier custom AgentPolicy class.
     policy_kwargs = {
-        'hidden_dim': config.hidden_dim,
+        "net_arch": [dict(pi=[config.hidden_dim], vf=[config.hidden_dim])],
     }
 
     print("Instantiating PPO agent...")
     model = PPO(
-        policy=AgentPolicy,
+        policy="MlpPolicy",
         env=env,
         learning_rate=config.learning_rate,
         n_steps=config.n_steps,
@@ -174,7 +172,6 @@ def train_agent(config: argparse.Namespace) -> None:
         verbose=1,
         tensorboard_log=str(log_dir / "tensorboard_logs"),
         device=device,
-        use_sde=False, # Add this line
     )
 
     # --- Start Training ---


### PR DESCRIPTION
## Summary
- remove unused `AgentPolicy` import in `train_agent.py`
- use standard `MlpPolicy` for PPO agent

## Testing
- `python test_all.py` *(fails: KeyboardInterrupt during long-running build)*

------
https://chatgpt.com/codex/tasks/task_e_684cf82d3e948331bbc0096cd0dd0c81

## Summary by Sourcery

Switch from a custom AgentPolicy to SB3’s built-in MlpPolicy for PPO, update the network architecture configuration accordingly, and remove unused code and parameters.

Bug Fixes:
- Fix PPO policy instantiation incompatibility by using the standard MlpPolicy

Enhancements:
- Adopt SB3’s MlpPolicy instead of the custom AgentPolicy class
- Update policy_kwargs to use a net_arch with hidden layers for both actor and critic

Chores:
- Remove unused AgentPolicy import in train_agent.py
- Remove obsolete use_sde parameter from PPO initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated agent training to use a standard neural network policy architecture, improving compatibility and maintainability.
  - Adjusted configuration options for specifying network layers.
  - Removed unused options to streamline agent setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->