### PR TITLE
Fix: Replace typographic apostrophes in CadQuery scripts

### DIFF
--- a/stls/lspo_3d/oracles/csg_executor.py
+++ b/stls/lspo_3d/oracles/csg_executor.py
@@ -75,6 +75,7 @@ def execute_cad_script(
     # 4. Use a try/except block to safely execute the script_string.
     try:
         # Execute the script within the defined scope
+        script_string = script_string.replace("’", "'")
         exec(script_string, sandbox_scope)
 
         # 5. After execution, retrieve the `result` object from the sandbox scope.


### PR DESCRIPTION
The CadQuery script executor was failing due to an "invalid character '’' (U+2019)" error. This occurred because typographic (or "smart") apostrophes were present in the script strings being executed.

This commit modifies the `execute_cad_script` function in `stls/lspo_3d/oracles/csg_executor.py` to replace the typographic apostrophe (U+2019) with a standard apostrophe (U+0027) before the script string is passed to `exec()`. This should prevent the error and allow the CadQuery scripts to be parsed correctly.

## Summary by Sourcery

Bug Fixes:
- Sanitize script input by replacing smart apostrophes with standard ones to avoid execution failures in `execute_cad_script`.