### PR TITLE
Fix CadQuery script execution by sanitizing text

### DIFF
--- a/stls/lspo_3d/oracles/csg_executor.py
+++ b/stls/lspo_3d/oracles/csg_executor.py
@@ -30,13 +30,7 @@ def _sanitize_script_string(script: str) -> str:
     This helper normalizes common curly quotes to standard ASCII quotes and
     strips characters outside the ASCII range.
     """
-    replacements = {
-        "“": '"',
-        "”": '"',
-        "‘": "'",
-        "’": "'",
-    }
-    for bad, good in replacements.items():
+    for bad, good in REPLACEMENTS.items():
         script = script.replace(bad, good)
     # Remove any remaining non-ASCII characters
     script = script.encode("ascii", "ignore").decode("ascii")


### PR DESCRIPTION
## Summary
- handle curly quotes in generated CadQuery scripts
- compile sanitized script before running

## Testing
- `python test_all.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684dff29f2508331996f3908b0afffd8

## Summary by Sourcery

Sanitize and compile CadQuery scripts before execution to prevent syntax errors from non-ASCII characters.

Bug Fixes:
- Normalize curly quotes and remove non-ASCII characters in scripts to avoid exec failures.

Enhancements:
- Compile the sanitized script prior to execution to catch syntax errors explicitly.