### PR TITLE
Auto-run motif discovery in training script

### DIFF
--- a/stls/run_agent_training.py
+++ b/stls/run_agent_training.py
@@ -28,6 +28,33 @@ except Exception as e:
 # Restore original argv
 sys.argv = original_argv
 
+# --- Step 1b: Ensure motif assignments exist ---
+motif_assignments_path = project_root / "artifacts" / "motifs" / "motif_assignments.pt"
+if not motif_assignments_path.exists():
+    print("--- Motif assignments not found. Running motif discovery ---")
+    motif_data_dir = project_root / "data" / "processed"
+    motif_output_dir = project_root / "artifacts" / "motifs"
+
+    sys.argv = [
+        "lspo_3d/train_motifs.py",
+        "--data_dir",
+        str(motif_data_dir),
+        "--output_dir",
+        str(motif_output_dir),
+        "--num_motifs",
+        "2",
+        "--model_name",
+        "distilbert-base-uncased",
+    ]
+    try:
+        runpy.run_module("lspo_3d.train_motifs", run_name="__main__")
+        print("--- Motif discovery completed ---")
+    except Exception as e:
+        print(f"--- Motif discovery failed: {e} ---")
+        sys.exit(1)
+    finally:
+        sys.argv = original_argv
+
 # --- Step 2: Run the Agent Training Script ---
 print("\n--- Running Agent Training ---")
 

--- a/stls/run_agent_training.py
+++ b/stls/run_agent_training.py
@@ -50,6 +50,8 @@ if not motif_assignments_path.exists():
         runpy.run_module("lspo_3d.train_motifs", run_name="__main__")
         print("--- Motif discovery completed ---")
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         print(f"--- Motif discovery failed: {e} ---")
         sys.exit(1)
     finally:


### PR DESCRIPTION
## Summary
- ensure `run_agent_training.py` triggers motif discovery if assignments are missing

## Testing
- `uv run stls/run_agent_training.py`
- `uv run test_all.py` *(fails: interrupted during long training)*

------
https://chatgpt.com/codex/tasks/task_e_684e0537b4548331b15eefdc31874df0

## Summary by Sourcery

Automatically trigger motif discovery during agent training if motif assignments are missing

Enhancements:
- Check for existing motif assignments and invoke the motif discovery module when absent
- Restore original command-line arguments and handle motif discovery errors gracefully before proceeding with agent training