### PR TITLE
Fix: Correct archive_logs functionality and improve error reporting

### DIFF
--- a/run.py
+++ b/run.py
@@ -101,7 +101,8 @@ if __name__ == "__main__":
 
 
     # Optional: Archive logs if needed
-    archive_logs()
+    archive_result = archive_logs()
+    print(f"Archive logs result: {archive_result}")
     display = AgentDisplayConsole()
 
     async def run_console_app():

--- a/utils/file_logger.py
+++ b/utils/file_logger.py
@@ -1,5 +1,6 @@
 import json
 import datetime
+import shutil
 from pathlib import Path
 from config import get_constant, LOGS_DIR
 
@@ -918,7 +919,7 @@ def archive_logs():
     """Archive all log files in LOGS_DIR by moving them to an archive folder with a timestamp."""
     try:
         # Create timestamp for the archive folder
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         archive_dir = Path(LOGS_DIR, "archive", timestamp)
         archive_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
This commit addresses issues in the archive_logs function:
- Added missing `import shutil` in `utils/file_logger.py`.
- Corrected `datetime.now()` to `datetime.datetime.now()` in `utils/file_logger.py`.
- Modified `run.py` to print the result of the `archive_logs()` call, aiding in future debugging.

These changes ensure that log archiving works as intended and provides better feedback in case of errors.