### PR TITLE
Fix WebUI event loop issue

### DIFF
--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -46,7 +46,7 @@ class WebUI:
         self.user_messages = []
         self.assistant_messages = []
         self.tool_results = []
-        self.input_queue = asyncio.Queue()
+        self.input_queue = Queue()
         self.agent_runner = agent_runner
         self.setup_routes()
         self.setup_socketio_events()
@@ -143,7 +143,7 @@ class WebUI:
         def handle_user_input(data):
             user_input = data.get("input", "")
             logging.info(f"Received user input: {user_input}")
-            self.input_queue.put_nowait(user_input)
+            self.input_queue.put(user_input)
         logging.info("SocketIO events set up")
 
     def start_server(self, host="0.0.0.0", port=5000):
@@ -177,5 +177,5 @@ class WebUI:
         Await the next user input sent via the web UI input queue.
         The prompt_message parameter is ignored in the web interface.
         """
-        return await self.input_queue.get()
+        return await asyncio.to_thread(self.input_queue.get)
 


### PR DESCRIPTION
## Summary
- fix WebUI to use thread-safe queue
- handle blocking queue with `asyncio.to_thread`

## Testing
- `PYTHONPATH=. pytest -q tests/tools/test_edit.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685f555585cc8331978818d3ea177f97