### PR TITLE
Use system prompt

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -21,7 +21,13 @@ from utils.web_ui import WebUI
 from utils.agent_display_console import AgentDisplayConsole
 from utils.context_helpers import extract_text_from_content, refresh_context_async
 from utils.output_manager import OutputManager
-from config import COMPUTER_USE_BETA_FLAG, PROMPT_CACHING_BETA_FLAG, MAIN_MODEL, MAX_SUMMARY_TOKENS
+from config import (
+    COMPUTER_USE_BETA_FLAG,
+    PROMPT_CACHING_BETA_FLAG,
+    MAIN_MODEL,
+    MAX_SUMMARY_TOKENS,
+    reload_system_prompt,
+)
 # from token_tracker import TokenTracker
 
 from dotenv import load_dotenv
@@ -48,7 +54,8 @@ class Agent:
             display=self.display,
         )
         self.output_manager = OutputManager(self.display)
-        self.messages = []
+        self.system_prompt = reload_system_prompt()
+        self.messages = [{"role": "system", "content": self.system_prompt}]
         self.client = OpenAI(
             api_key=os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY"),
             base_url=os.getenv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1"),

--- a/config.py
+++ b/config.py
@@ -88,8 +88,14 @@ def set_prompt_name(name: str):
 # --- System Prompt Loading ---
 try:
     with open(SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
-        SYSTEM_PROMPT = f.read()
-    SYSTEM_PROMPT += f"\n\nHost operating system: {OS_NAME}. Use appropriate commands for this environment."
+        _prompt_contents = f.read()
+    if "{{OS_NAME}}" in _prompt_contents:
+        SYSTEM_PROMPT = _prompt_contents.replace("{{OS_NAME}}", OS_NAME)
+    else:
+        SYSTEM_PROMPT = _prompt_contents + (
+            f"\n\nHost operating system: {OS_NAME}. "
+            "Use appropriate commands for this environment."
+        )
 except FileNotFoundError:
     SYSTEM_PROMPT = "System prompt file not found. Please ensure 'system_prompt/system_prompt.md' exists."
     logging.error(f"CRITICAL: System prompt file not found at {SYSTEM_PROMPT_FILE}")
@@ -102,8 +108,14 @@ def reload_system_prompt() -> str:
     global SYSTEM_PROMPT
     try:
         with open(SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
-            SYSTEM_PROMPT = f.read()
-        SYSTEM_PROMPT += f"\n\nHost operating system: {OS_NAME}. Use appropriate commands for this environment."
+            contents = f.read()
+        if "{{OS_NAME}}" in contents:
+            SYSTEM_PROMPT = contents.replace("{{OS_NAME}}", OS_NAME)
+        else:
+            SYSTEM_PROMPT = contents + (
+                f"\n\nHost operating system: {OS_NAME}. "
+                "Use appropriate commands for this environment."
+            )
         logging.info(f"System prompt reloaded from {SYSTEM_PROMPT_FILE}")
         return SYSTEM_PROMPT
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- load OS-specific system prompt in config
- insert system prompt as first message when creating an Agent

## Testing
- `pytest -q` *(fails: Command uv run stls/runner.py not found)*
- `pytest tests/tools -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_685f74b93a0c8331bc3581817f349b27