### PR TITLE
Add web interface instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OPENAI_BASE_URL=https://openrouter.ai/api/v1  # optional override for OpenRouter
 Execute:
 
 ```bash
-python run.py
+python run.py console
 ```
 
 ## Running the web UI
@@ -47,11 +47,13 @@ To use the interactive web interface, run:
 python run.py web
 ```
 
-By default the server starts on port 5001. Open your browser to:
+By default the server starts on port 5000. Open your browser to:
 
 ```
-http://localhost:5001/
+http://localhost:5000/
 ```
+
+For a detailed walkthrough see [docs/web_interface_guide.md](docs/web_interface_guide.md).
 
 The script loads environment variables with `dotenv` and launches the `AgentDisplayConsole`. You will be prompted to choose a prompt from `prompts/` or create a new one. After choosing a task, the agent runs, using tools and displaying output directly in the terminal.
 

--- a/docs/web_interface_guide.md
+++ b/docs/web_interface_guide.md
@@ -1,0 +1,29 @@
+# Slaze Web Interface Guide
+
+This guide explains how to run the Slaze agent with the built-in web interface.
+
+## Prerequisites
+
+1. **Python**: Ensure Python 3.12 is installed. The specific version used for development is listed in `.python-version`.
+2. **Dependencies**: Install the required packages with:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Environment Variables**: At a minimum you need an API key for OpenAI or OpenRouter. Set them via environment variables or a `.env` file in the repository root. Example `.env`:
+   ```
+   OPENROUTER_API_KEY=your-key-here
+   OPENAI_BASE_URL=https://openrouter.ai/api/v1  # optional
+   ```
+
+## Running the Web Interface
+
+1. From the project root, start the web server:
+   ```bash
+   python run.py web
+   ```
+2. The server listens on port `5000` by default. The port can be changed with the `--port` option.
+3. Open your browser to `http://localhost:5000/` (or the port you specified).
+4. Use the interface to select an existing prompt or create a new one, then click **Start** to launch the agent.
+5. The agent will stream its conversation to the page. Logs and generated files are stored under the `logs/` and `repo/` directories.
+
+For command line usage, see the main [README](../README.md).


### PR DESCRIPTION
## Summary
- document how to run the Slaze web UI
- update README with correct port and console command

## Testing
- `PYTHONPATH=. pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6861d5fb64ec83318d4810fac8d10337