### PR TITLE
Improve web UI for post-tool interaction

### DIFF
--- a/docs/web_interface_guide.md
+++ b/docs/web_interface_guide.md
@@ -26,4 +26,9 @@ This guide explains how to run the Slaze agent with the built-in web interface.
 4. Use the interface to select an existing prompt or create a new one, then click **Start** to launch the agent.
 5. The agent will stream its conversation to the page. Logs and generated files are stored under the `logs/` and `repo/` directories.
 
+   When the agent has no further tool calls to make, the page now displays a
+   prompt asking whether you would like to provide additional instructions or
+   exit. Enter your response in the text box and press **Send**. Typing `exit`
+   ends the session.
+
 For command line usage, see the main [README](../README.md).

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -175,7 +175,18 @@ class WebUI:
         )
 
     async def wait_for_user_input(self, prompt_message: str = None) -> str:
-        """Await the next user input sent via the web UI input queue."""
+        """Await and return the next user input from the web UI.
+
+        If ``prompt_message`` is provided, it will be displayed to the user so
+        they know the application is waiting for instructions. This mirrors the
+        behaviour of the console interface where a prompt is printed before
+        reading input.
+        """
+        if prompt_message:
+            # Display the prompt message in the UI so the user knows what to do
+            self.add_message("assistant", prompt_message)
+
         loop = asyncio.get_running_loop()
+        # Wait for the next message submitted via the web interface
         return await loop.run_in_executor(None, self.input_queue.get)
 


### PR DESCRIPTION
## Summary
- notify users via the web interface when the agent has no more tool calls
- document the new behaviour in the web interface guide

## Testing
- `pip install pytest-asyncio`
- `PYTHONPATH=. pytest -q tests/tools/test_edit.py`

------
https://chatgpt.com/codex/tasks/task_e_6861fcc1d33883319c8ae4474fca75d2