### PR TITLE
Fix: Web UI prompts user for input when agent has no tool calls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
         <div class="messages" id="messages">
             <!-- Messages will be loaded here -->
         </div>
+        <div id="agent_prompt_area" class="agent-prompt" style="margin-top: 10px; margin-bottom: 10px; padding: 10px; background-color: #f0f0f0; border-radius: 4px; text-align: center; display: none;"></div>
         <div class="input-area">
             <textarea id="user_input" placeholder="Type your message here..."></textarea>
             <button onclick="sendMessage()">Send</button>
@@ -62,12 +63,34 @@
             messagesDiv.scrollTop = messagesDiv.scrollHeight; // Scroll to bottom
         });
 
+        socket.on('agent_prompt', function(data) {
+            var promptArea = document.getElementById('agent_prompt_area');
+            if (data.message) {
+                promptArea.textContent = data.message;
+                promptArea.style.display = 'block';
+            } else {
+                promptArea.textContent = '';
+                promptArea.style.display = 'none';
+            }
+        });
+
+        socket.on('agent_prompt_clear', function() {
+            var promptArea = document.getElementById('agent_prompt_area');
+            promptArea.textContent = '';
+            promptArea.style.display = 'none';
+        });
+
         function sendMessage() {
             var input = document.getElementById('user_input');
+            var promptArea = document.getElementById('agent_prompt_area');
             var message = input.value;
             if (message.trim() !== '') {
                 socket.emit('user_input', { input: message });
                 input.value = '';
+                // It's better to rely on agent_prompt_clear from backend
+                // but as a fallback, hide it immediately on send.
+                // promptArea.textContent = '';
+                // promptArea.style.display = 'none';
             }
         }
 

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -176,6 +176,16 @@ class WebUI:
 
     async def wait_for_user_input(self, prompt_message: str = None) -> str:
         """Await the next user input sent via the web UI input queue."""
+        if prompt_message:
+            logging.info(f"Emitting agent_prompt: {prompt_message}")
+            self.socketio.emit("agent_prompt", {"message": prompt_message})
+
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self.input_queue.get)
+        user_response = await loop.run_in_executor(None, self.input_queue.get)
+
+        # Clear the prompt after input is received
+        logging.info("Emitting agent_prompt_clear")
+        self.socketio.emit("agent_prompt_clear")
+
+        return user_response
 


### PR DESCRIPTION
Previously, the web interface would appear to freeze when the agent completed its operations or had no further tool calls, as it wasn't clear that user input was expected.

This change implements a prompting mechanism similar to the console version:

- Modified `utils/web_ui.py` for the `WebUI.wait_for_user_input` method to emit a SocketIO event (`agent_prompt`) with the prompt message to the client before waiting for input.
- It also emits an `agent_prompt_clear` event after input is received.
- Modified `templates/index.html` to add a dedicated area for this prompt and JavaScript handlers for the `agent_prompt` and `agent_prompt_clear` events to display and then hide the prompt.

This makes the web interface more interactive by clearly indicating when user input is required.