### PR TITLE
Fix web mode address detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,9 @@ To use the interactive web interface, run:
 python run.py web
 ```
 
-By default the server starts on port 5000. Open your browser to:
-
-```
-http://localhost:5000/
-```
+By default the server starts on port 5000. The CLI attempts to detect your
+machine's LAN IP so you can open a browser on another device if needed.
+Open your browser to the printed address (e.g. `http://192.168.x.x:5000/`).
 
 For a detailed walkthrough see [docs/web_interface_guide.md](docs/web_interface_guide.md).
 

--- a/docs/web_interface_guide.md
+++ b/docs/web_interface_guide.md
@@ -22,7 +22,8 @@ This guide explains how to run the Slaze agent with the built-in web interface.
    python run.py web
    ```
 2. The server listens on port `5000` by default. The port can be changed with the `--port` option.
-3. Open your browser to `http://localhost:5000/` (or the port you specified).
+3. The CLI prints the address of the running server using your local IP. Open
+   your browser to that address (for example `http://192.168.x.x:5000/`).
 4. Use the interface to select an existing prompt or create a new one, then click **Start** to launch the agent.
 5. The agent will stream its conversation to the page. Logs and generated files are stored under the `logs/` and `repo/` directories.
 

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import click
 
 from dotenv import load_dotenv
 import webbrowser
+import socket
 
 from agent import Agent
 from utils.agent_display_console import AgentDisplayConsole
@@ -51,10 +52,19 @@ def console():
 @click.option('--port', default=5000, help='Port to run the web server on.')
 def web(port):
     """Run the agent with a web interface."""
-    
+
     display = WebUI(run_agent_async)
-    
-    url = f"http://localhost:{port}"
+
+    # Determine the local IP address for convenience when accessing from
+    # another machine on the network. Fallback to localhost if detection fails.
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("10.255.255.255", 1))
+            host_ip = s.getsockname()[0]
+    except Exception:
+        host_ip = "localhost"
+
+    url = f"http://{host_ip}:{port}"
     print(f"Web server started on port {port}. Opening your browser to {url}")
     webbrowser.open(url)
     print("Waiting for user to start a task from the web interface.")


### PR DESCRIPTION
## Summary
- open the web UI on the machine's LAN IP instead of localhost
- avoid prompting for input during tests unless needed
- document the new IP behaviour in README and web interface guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620a3679d883318b2a32204af1e0ec

## Summary by Sourcery

Detect and use the host’s LAN IP for the web UI, improve tool_call serialization, restrict prompts to interactive sessions, and update documentation to reflect the new behavior.

New Features:
- Open web interface on the machine’s LAN IP by default with fallback to localhost.

Bug Fixes:
- Serialize tool call objects by falling back to __dict__ when to_dict is unavailable.

Enhancements:
- Only prompt for user input in interactive displays to avoid blocking during tests.

Documentation:
- Update README and web interface guide to explain LAN IP detection for accessing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The web interface can now be accessed from other devices on the same network using your machine's LAN IP address, making it easier to use across multiple devices.

* **Documentation**
  * Updated instructions and guides to reflect the new method for accessing the web interface, directing users to use the printed LAN IP address instead of a fixed localhost URL.

* **Bug Fixes**
  * Improved handling of tool call serialization and user prompts, preventing unnecessary prompts in non-interactive or testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->