### PR TITLE
Add host option for web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ python run.py console
 
 To use the interactive web interface, run:
 
+
 ```bash
 python run.py web
 ```
 
-By default the server starts on port 5000. Open your browser to:
+By default the server starts on host `0.0.0.0` on port `5000`. You can change these with the `--host` and `--port` options. After starting the server open your browser to:
 
 ```
 http://localhost:5000/
 ```
+
+If `localhost` does not resolve correctly on your machine, replace it with the IP address specified via `--host`.
 
 For a detailed walkthrough see [docs/web_interface_guide.md](docs/web_interface_guide.md).
 

--- a/docs/web_interface_guide.md
+++ b/docs/web_interface_guide.md
@@ -21,8 +21,9 @@ This guide explains how to run the Slaze agent with the built-in web interface.
    ```bash
    python run.py web
    ```
-2. The server listens on port `5000` by default. The port can be changed with the `--port` option.
-3. Open your browser to `http://localhost:5000/` (or the port you specified).
+2. The server listens on host `0.0.0.0` and port `5000` by default. Both can be changed with the `--host` and `--port` options.
+3. Open your browser to `http://localhost:5000/` (or the host/port you specified).
+   If `localhost` does not work, use the IP address you provided to `--host`.
 4. Use the interface to select an existing prompt or create a new one, then click **Start** to launch the agent.
 5. The agent will stream its conversation to the page. Logs and generated files are stored under the `logs/` and `repo/` directories.
 

--- a/run.py
+++ b/run.py
@@ -49,17 +49,19 @@ def console():
 
 @cli.command()
 @click.option('--port', default=5000, help='Port to run the web server on.')
-def web(port):
+@click.option('--host', default='0.0.0.0', help='Host interface to bind the web server.')
+def web(port, host):
     """Run the agent with a web interface."""
     
     display = WebUI(run_agent_async)
     
-    url = f"http://localhost:{port}"
-    print(f"Web server started on port {port}. Opening your browser to {url}")
+    url_host = 'localhost' if host in ['0.0.0.0', ''] else host
+    url = f"http://{url_host}:{port}"
+    print(f"Web server started on {host}:{port}. Opening your browser to {url}")
     webbrowser.open(url)
     print("Waiting for user to start a task from the web interface.")
     
-    display.start_server(port=port)
+    display.start_server(host=host, port=port)
     
     # The Flask-SocketIO server is a blocking call that will keep the application
     # alive. It's started in display.start_server().


### PR DESCRIPTION
## Summary
- allow specifying host when starting web UI
- document how to use `--host` option in README and web interface guide

## Testing
- `pytest -q` *(fails: 3 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68620a3679d883318b2a32204af1e0ec