### PR TITLE
Move task.txt to the log directory

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -138,15 +138,9 @@ class Agent:
         revised_task_from_llm = await call_llm_for_task_revision(initial_task, self.client, MAIN_MODEL)
         logger.info(f"Task revision result: '{initial_task[:100]}...' -> '{revised_task_from_llm[:100]}...'")
 
-        repo_dir_val = get_constant("REPO_DIR")
-        if not repo_dir_val:
-            logger.error("REPO_DIR not found in constants. Cannot save revised task.txt.")
-            # Fallback: update self.task and TASK constant but don't write to file.
-            set_constant("TASK", revised_task_from_llm)
-            return revised_task_from_llm
-
-        repo_dir = Path(repo_dir_val)
-        task_file_path = repo_dir / "logs" / "task.txt"
+        # Save task.txt to the logs directory instead of repo/logs
+        logs_dir = Path.cwd() / "logs"
+        task_file_path = logs_dir / "task.txt"
 
         try:
             task_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/agent.py
+++ b/agent.py
@@ -138,8 +138,15 @@ class Agent:
         revised_task_from_llm = await call_llm_for_task_revision(initial_task, self.client, MAIN_MODEL)
         logger.info(f"Task revision result: '{initial_task[:100]}...' -> '{revised_task_from_llm[:100]}...'")
 
-        # Save task.txt to the logs directory instead of repo/logs
-        logs_dir = Path.cwd() / "logs"
+        # Use the LOGS_DIR constant from config
+        logs_dir = get_constant("LOGS_DIR")
+        if not logs_dir:
+            logger.error("LOGS_DIR not found in constants. Cannot save revised task.txt.")
+            # Fallback: update TASK constant but don't write to file.
+            set_constant("TASK", revised_task_from_llm)
+            return revised_task_from_llm
+
+        logs_dir = Path(logs_dir)
         task_file_path = logs_dir / "task.txt"
 
         try:

--- a/tools/write_code.py
+++ b/tools/write_code.py
@@ -724,18 +724,23 @@ class WriteCodeTool(BaseAnthropicTool):
         Tries to read the task description from various locations.
         Returns the task description or a default message if not found.
         """
-        # Priority order: logs/task.txt first, then repo/logs/task.txt, then project root
-        possible_paths = [
-            os.path.join("logs", "task.txt"),  # Primary location
-        ]
+        possible_paths = []
         
-        # Add repo/logs/task.txt as fallback for backward compatibility
+        # Primary location: Use LOGS_DIR constant
+        logs_dir = get_constant("LOGS_DIR")
+        if logs_dir:
+            possible_paths.append(os.path.join(str(logs_dir), "task.txt"))
+        
+        # Fallback for backward compatibility: repo/logs/task.txt
         repo_dir = get_constant("REPO_DIR")
-        if repo_dir and isinstance(repo_dir, str): # Ensure repo_dir is a string
-            possible_paths.append(os.path.join(repo_dir, "logs", "task.txt"))
+        if repo_dir:
+            possible_paths.append(os.path.join(str(repo_dir), "logs", "task.txt"))
         
-        # Add project root as final fallback
-        possible_paths.append("task.txt")
+        # Additional fallbacks for backward compatibility
+        possible_paths.extend([
+            os.path.join("logs", "task.txt"),  # Relative logs directory
+            "task.txt"  # Project root
+        ])
 
         for path in possible_paths:
             try:

--- a/tools/write_code.py
+++ b/tools/write_code.py
@@ -724,14 +724,18 @@ class WriteCodeTool(BaseAnthropicTool):
         Tries to read the task description from various locations.
         Returns the task description or a default message if not found.
         """
+        # Priority order: logs/task.txt first, then repo/logs/task.txt, then project root
+        possible_paths = [
+            os.path.join("logs", "task.txt"),  # Primary location
+        ]
+        
+        # Add repo/logs/task.txt as fallback for backward compatibility
         repo_dir = get_constant("REPO_DIR")
-        possible_paths = []
         if repo_dir and isinstance(repo_dir, str): # Ensure repo_dir is a string
             possible_paths.append(os.path.join(repo_dir, "logs", "task.txt"))
-        possible_paths.extend([
-            os.path.join("logs", "task.txt"),
-            "task.txt"
-        ])
+        
+        # Add project root as final fallback
+        possible_paths.append("task.txt")
 
         for path in possible_paths:
             try:


### PR DESCRIPTION
Save and read `task.txt` using the `LOGS_DIR` constant to ensure it is consistently placed in the designated logs directory.

## Summary by Sourcery

Use the LOGS_DIR constant to standardize reading and writing of task.txt while preserving backward compatibility with legacy paths.

Enhancements:
- Prioritize LOGS_DIR when locating task.txt and fall back to REPO_DIR and legacy locations for reading.
- Switch task revision saving to use LOGS_DIR and adjust error logging when LOGS_DIR is missing.
- Ensure the target logs directory is created before writing task.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of task file locations, prioritizing the latest logs directory and maintaining compatibility with older file locations.
  * Enhanced error logging to reflect updated directory usage for task files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->