### PR TITLE
Add Toolbox UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -131,6 +131,7 @@
         <div class="header">
             <h1>Slazy Agent</h1>
             <a href="/select_prompt">Select/Create Prompt</a>
+            <a href="/tools" style="margin-left:15px;">Toolbox</a>
         </div>
         
         <div class="tab-container">

--- a/templates/select_prompt.html
+++ b/templates/select_prompt.html
@@ -46,6 +46,7 @@
             <button type="submit">Submit Prompt</button>
         </form>
         <a href="/" class="back-link">Back to Agent</a>
+        <a href="/tools" class="back-link">Toolbox</a>
     </div>
 
     <script>

--- a/templates/tool_form.html
+++ b/templates/tool_form.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ tool_name }}</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 20px; background-color: #f4f4f4; }
+        .container { max-width: 900px; margin: auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        form div { margin-bottom: 15px; }
+        label { display: block; margin-bottom: 5px; font-weight: bold; }
+        input[type="text"], textarea, select { width: 100%; padding: 8px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        textarea { min-height: 100px; resize: vertical; }
+        button { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        button:hover { background-color: #0056b3; }
+        pre { background: #f0f0f0; padding: 10px; border-radius: 4px; }
+        .back-link { display: block; margin-top: 20px; text-decoration: none; color: #007bff; }
+        .back-link:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{{ tool_name }}</h1>
+        <form method="post">
+            {% for param, info in params.properties.items() %}
+            <div>
+                <label for="{{ param }}">{{ param }}</label>
+                {% if info.enum %}
+                <select name="{{ param }}" id="{{ param }}">
+                    {% for opt in info.enum %}
+                    <option value="{{ opt }}">{{ opt }}</option>
+                    {% endfor %}
+                </select>
+                {% elif info.type == 'array' %}
+                <textarea name="{{ param }}" id="{{ param }}" placeholder="Enter JSON array"></textarea>
+                {% else %}
+                <input type="text" name="{{ param }}" id="{{ param }}">
+                {% endif %}
+            </div>
+            {% endfor %}
+            <button type="submit">Run {{ tool_name }}</button>
+        </form>
+        {% if result %}
+        <h2>Result</h2>
+        <pre>{{ result }}</pre>
+        {% endif %}
+        <a href="{{ url_for('tools_route') }}" class="back-link">Back to Tools</a>
+    </div>
+</body>
+</html>

--- a/templates/tool_list.html
+++ b/templates/tool_list.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Toolbox</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 20px; background-color: #f4f4f4; }
+        .container { max-width: 900px; margin: auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .tool { border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; border-radius: 6px; }
+        button { padding: 8px 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        button:hover { background-color: #0056b3; }
+        .back-link { display: block; margin-top: 20px; text-decoration: none; color: #007bff; }
+        .back-link:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Available Tools</h1>
+        {% for tool in tools %}
+        <div class="tool">
+            <h2>{{ tool.name }}</h2>
+            <p>{{ tool.description }}</p>
+            <form action="{{ url_for('run_tool_route', tool_name=tool.name) }}" method="get">
+                <button type="submit">Use {{ tool.name }}</button>
+            </form>
+        </div>
+        {% endfor %}
+        <a href="/" class="back-link">Back</a>
+    </div>
+</body>
+</html>

--- a/tests/web/test_toolbox.py
+++ b/tests/web/test_toolbox.py
@@ -1,0 +1,21 @@
+import pytest
+from utils.web_ui import WebUI
+
+@pytest.fixture
+def client():
+    ui = WebUI(lambda *a, **k: None)
+    ui.app.testing = True
+    return ui.app.test_client()
+
+
+def test_tools_page(client):
+    resp = client.get('/tools')
+    assert resp.status_code == 200
+    # basic check for at least one tool name in response
+    assert b'bash' in resp.data
+
+
+def test_run_bash_tool(client):
+    resp = client.post('/tools/bash', data={'command': 'echo test'})
+    assert resp.status_code == 200
+    assert b'test' in resp.data

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import threading
 import logging
+import json
 from queue import Queue
 from flask import Flask, render_template, jsonify, request, redirect, url_for, send_from_directory
 from flask_socketio import SocketIO, disconnect
@@ -49,6 +50,24 @@ class WebUI:
         # Using a standard Queue for cross-thread communication
         self.input_queue = Queue()
         self.agent_runner = agent_runner
+        # Import tools lazily to avoid circular imports
+        from tools import (
+            BashTool,
+            ProjectSetupTool,
+            WriteCodeTool,
+            PictureGenerationTool,
+            EditTool,
+            ToolCollection,
+        )
+
+        self.tool_collection = ToolCollection(
+            WriteCodeTool(display=self),
+            ProjectSetupTool(display=self),
+            BashTool(display=self),
+            PictureGenerationTool(display=self),
+            EditTool(display=self),
+            display=self,
+        )
         self.setup_routes()
         self.setup_socketio_events()
         logging.info("WebUI initialized")
@@ -127,6 +146,53 @@ class WebUI:
             except FileNotFoundError:
                 logging.error(f"Prompt not found: {filename}")
                 return "Prompt not found", 404
+
+        @self.app.route("/tools")
+        def tools_route():
+            """Display available tools."""
+            tool_list = []
+            for tool in self.tool_collection.tools.values():
+                info = tool.to_params()["function"]
+                tool_list.append({"name": info["name"], "description": info["description"]})
+            return render_template("tool_list.html", tools=tool_list)
+
+        @self.app.route("/tools/<tool_name>", methods=["GET", "POST"])
+        def run_tool_route(tool_name):
+            """Run an individual tool from the toolbox."""
+            tool = self.tool_collection.tools.get(tool_name)
+            if not tool:
+                return "Tool not found", 404
+            params = tool.to_params()["function"]["parameters"]
+            result_text = None
+            if request.method == "POST":
+                tool_input = {}
+                for param in params.get("properties", {}):
+                    value = request.form.get(param)
+                    if value:
+                        pinfo = params["properties"].get(param, {})
+                        if pinfo.get("type") == "integer":
+                            try:
+                                tool_input[param] = int(value)
+                            except ValueError:
+                                tool_input[param] = value
+                        elif pinfo.get("type") == "array":
+                            try:
+                                tool_input[param] = json.loads(value)
+                            except Exception:
+                                tool_input[param] = [v.strip() for v in value.split(',') if v.strip()]
+                        else:
+                            tool_input[param] = value
+                try:
+                    result = asyncio.run(self.tool_collection.run(tool_name, tool_input))
+                    result_text = result.output or result.error
+                except Exception as exc:
+                    result_text = str(exc)
+            return render_template(
+                "tool_form.html",
+                tool_name=tool_name,
+                params=params,
+                result=result_text,
+            )
         logging.info("Routes set up")
 
     def setup_socketio_events(self):


### PR DESCRIPTION
## Summary
- add links to new toolbox page
- create basic toolbox templates
- allow WebUI to run tools from the toolbox
- test toolbox routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686aa490ff1483319449c0c372260ddf

## Summary by Sourcery

Add a Toolbox UI to the WebUI by integrating ToolCollection, setting up new routes and templates for listing and running tools, adding navigation links, and covering functionality with tests.

New Features:
- Add "/tools" and "/tools/<tool_name>" routes to list and execute available toolbox tools through the Web UI
- Integrate ToolCollection into WebUI to enable running tools via the interface
- Add navigation links to access the toolbox from the main and prompt selection pages
- Provide HTML templates for toolbox tool listing (tool_list.html) and execution forms (tool_form.html)

Enhancements:
- Lazily import tool modules in WebUI initialization to avoid circular dependencies

Tests:
- Add end-to-end tests for the toolbox UI, verifying the tools page and running the bash tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Toolbox" section accessible via new navigation links in the main and prompt selection pages.
  * Added a dedicated page listing available tools with descriptions and access to individual tool interfaces.
  * Enabled interactive forms for running specific tools directly from the web interface, supporting dynamic parameter input and result display.

* **Tests**
  * Added tests to verify accessibility of the tools page and correct execution of a sample tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->