### PR TITLE
Add interactive tool confirmation option

### DIFF
--- a/agent_test.py
+++ b/agent_test.py
@@ -67,7 +67,7 @@ def test_agent_init(task, display_type):
     # Arrange
 
     # Act
-    agent = Agent(task, display_type())
+    agent = Agent(task, display_type(), manual_tool_confirmation=False)
 
     # Assert
     assert agent.task == task
@@ -119,7 +119,7 @@ def test_agent_init(task, display_type):
 )
 def test_log_tool_results(tmp_path, combined_content, tool_name, tool_input, expected_lines, case_id):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     log_file = tmp_path / "tool.txt"
     os.makedirs(tmp_path, exist_ok=True)
     # Patch open to write to tmp_path
@@ -146,7 +146,7 @@ def test_log_tool_results(tmp_path, combined_content, tool_name, tool_input, exp
 )
 async def test_make_api_tool_result(tool_result, content_block, expected_is_error, expected_output, case_id):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
 
     # Act
     result = agent._make_api_tool_result(tool_result, content_block["id"])
@@ -172,7 +172,7 @@ async def test_make_api_tool_result(tool_result, content_block, expected_is_erro
 )
 async def test_run_tool(tool_run_result, run_raises, expected_output, expected_error, case_id):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     content_block = {"name": "tool", "id": "tid", "input": {"foo": "bar"}}
     if run_raises:
         async def raise_exc(*a, **k): raise Exception("fail")
@@ -225,7 +225,7 @@ async def test_run_tool(tool_run_result, run_raises, expected_output, expected_e
 )
 def test_inject_prompt_caching(messages, expected_breakpoints, case_id):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = messages.copy()
 
     # Act
@@ -252,7 +252,7 @@ def test_inject_prompt_caching(messages, expected_breakpoints, case_id):
 )
 def test_sanitize_tool_name(name, expected, case_id):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
 
     # Act
     result = agent._sanitize_tool_name(name)
@@ -263,7 +263,7 @@ def test_sanitize_tool_name(name, expected, case_id):
 @pytest.mark.asyncio
 async def test_step_happy(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     fake_response = types.SimpleNamespace()
     fake_msg = types.SimpleNamespace()
@@ -283,7 +283,7 @@ async def test_step_happy(monkeypatch):
 @pytest.mark.asyncio
 async def test_step_llm_error(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     agent.client.chat.completions.create = MagicMock(side_effect=Exception("fail"))
     agent.display = DummyDisplay()
@@ -300,7 +300,7 @@ async def test_step_llm_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_step_with_tool_calls(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     fake_tc = types.SimpleNamespace()
     fake_tc.function = types.SimpleNamespace()
@@ -332,7 +332,7 @@ async def test_step_with_tool_calls(monkeypatch):
 @pytest.mark.asyncio
 async def test_step_with_tool_calls_no_content(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     fake_tc = types.SimpleNamespace()
     fake_tc.function = types.SimpleNamespace()
@@ -364,7 +364,7 @@ async def test_step_with_tool_calls_no_content(monkeypatch):
 @pytest.mark.asyncio
 async def test_step_no_tool_calls_user_exit(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     fake_response = types.SimpleNamespace()
     fake_msg = types.SimpleNamespace()
@@ -384,7 +384,7 @@ async def test_step_no_tool_calls_user_exit(monkeypatch):
 @pytest.mark.asyncio
 async def test_step_no_tool_calls_user_continue(monkeypatch):
     # Arrange
-    agent = Agent("task", DummyDisplay())
+    agent = Agent("task", DummyDisplay(), manual_tool_confirmation=False)
     agent.messages = [{"role": "user", "content": "hi"}]
     fake_response = types.SimpleNamespace()
     fake_msg = types.SimpleNamespace()

--- a/run_old.py
+++ b/run_old.py
@@ -84,7 +84,7 @@ async def run_sampling_loop(
             "API key not found. Please set the OPENROUTER_API_KEY or OPENAI_API_KEY environment variable."
         )
     # set the task as a constant in config
-    agent = Agent(task=task, display=display)
+    agent = Agent(task=task, display=display, manual_tool_confirmation=False)
     agent.messages.append({"role": "user", "content": task})
     messages = await sampling_loop(
         agent=agent,

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,15 +114,32 @@
         .header a { text-decoration: none; color: #007bff; font-weight: 500; }
         .header a:hover { text-decoration: underline; }
         
-        #agent_prompt_area { 
-            margin: 15px 0; 
-            padding: 12px; 
-            background-color: #fff3cd; 
-            border: 1px solid #ffeaa7; 
-            border-radius: 6px; 
-            text-align: center; 
+        #agent_prompt_area {
+            margin: 15px 0;
+            padding: 12px;
+            background-color: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 6px;
+            text-align: center;
             display: none;
             font-weight: 500;
+        }
+
+        #tool_prompt_modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.5);
+            display: none;
+        }
+        #tool_prompt_modal .modal-content {
+            background: white;
+            padding: 20px;
+            margin: 10% auto;
+            max-width: 500px;
+            border-radius: 6px;
         }
     </style>
 </head>
@@ -167,6 +184,13 @@
         </div>
         
         <div id="agent_prompt_area"></div>
+
+        <div id="tool_prompt_modal">
+            <div class="modal-content">
+                <h3 id="tool_prompt_title"></h3>
+                <form id="tool_prompt_form"></form>
+            </div>
+        </div>
         
         <div class="input-area">
             <textarea id="user_input" placeholder="Type your message here..."></textarea>
@@ -278,6 +302,72 @@
             promptArea.textContent = '';
             promptArea.style.display = 'none';
         });
+
+        socket.on('tool_prompt', function(data) {
+            showToolPrompt(data);
+        });
+
+        socket.on('tool_prompt_clear', function() {
+            document.getElementById('tool_prompt_modal').style.display = 'none';
+        });
+
+        function showToolPrompt(data) {
+            var modal = document.getElementById('tool_prompt_modal');
+            var form = document.getElementById('tool_prompt_form');
+            var title = document.getElementById('tool_prompt_title');
+            title.textContent = 'Confirm ' + data.tool;
+            form.innerHTML = '';
+            var props = (data.schema && data.schema.properties) || {};
+            for (var param in props) {
+                var info = props[param];
+                var value = data.values && data.values[param] !== undefined ? data.values[param] : '';
+                var label = document.createElement('label');
+                label.textContent = param;
+                form.appendChild(label);
+                var input;
+                if (info.enum) {
+                    input = document.createElement('select');
+                    info.enum.forEach(function(opt) {
+                        var o = document.createElement('option');
+                        o.value = opt;
+                        o.textContent = opt;
+                        if (opt == value) o.selected = true;
+                        input.appendChild(o);
+                    });
+                } else if (info.type === 'array') {
+                    input = document.createElement('textarea');
+                    input.value = Array.isArray(value) ? JSON.stringify(value) : value;
+                } else {
+                    input = document.createElement('input');
+                    input.type = 'text';
+                    input.value = value;
+                }
+                input.name = param;
+                form.appendChild(input);
+            }
+            var submit = document.createElement('button');
+            submit.type = 'submit';
+            submit.textContent = 'Run';
+            form.appendChild(submit);
+            form.onsubmit = function(e) {
+                e.preventDefault();
+                var result = {};
+                for (var param in props) {
+                    var el = form.querySelector('[name="' + param + '"]');
+                    var val = el.value;
+                    if (props[param].type === 'integer') {
+                        var parsed = parseInt(val);
+                        if (!isNaN(parsed)) val = parsed;
+                    } else if (props[param].type === 'array') {
+                        try { val = JSON.parse(val); } catch (err) { val = val.split(',').map(function(v){return v.trim();}).filter(function(v){return v;}); }
+                    }
+                    result[param] = val;
+                }
+                socket.emit('tool_response', { input: result });
+                modal.style.display = 'none';
+            };
+            modal.style.display = 'block';
+        }
 
         function sendMessage() {
             var input = document.getElementById('user_input');

--- a/tools/bash.py
+++ b/tools/bash.py
@@ -155,12 +155,10 @@ class BashTool(BaseTool):
             )
             rr(formatted_output)
             return ToolResult(
-                output=output,
+                output=formatted_output,
                 error=error,
-                #success=success,
                 tool_name=self.name,
                 command=command,
-                #working_directory=cwd,
             )
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- allow launching in a mode that asks for confirmation of tool calls
- support interactive tool editing for console and web UI
- show modal in web interface to adjust tool parameters
- include formatted output for bash commands

## Testing
- `PYTHONPATH=. pytest -q` *(fails: Command conversion needs OPENROUTER_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_686c45a9ad5483319c53c3aa2d6f75f9