### PR TITLE
feat: Implement interactive tool call inspection and modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ OPENROUTER_API_KEY=...  # or OPENAI_API_KEY
 OPENAI_BASE_URL=https://openrouter.ai/api/v1  # optional override for OpenRouter
 ```
 
+## Command-Line Options
+
+When running `run.py`, you can use the following command-line options:
+
+*   `--interactive-tool-calls`:
+    *   When this flag is provided, the agent will pause before executing any tool call.
+    *   It will display the tool name and the parameters it intends to use.
+    *   You will be prompted to:
+        *   **Approve** the tool call as is.
+        *   **Edit** the parameters (you'll be asked to provide the new parameters as a JSON string in the console, or through a UI in the web version).
+        *   **Cancel** the tool call.
+    *   This feature is useful for debugging, fine-grained control over tool execution, or guiding the agent more precisely.
+    *   Example: `python run.py --interactive-tool-calls console` or `python run.py --interactive-tool-calls web`.
+
 ## Running the console app
 
 Execute:

--- a/tests/utils/test_agent_display_console.py
+++ b/tests/utils/test_agent_display_console.py
@@ -1,0 +1,175 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from utils.agent_display_console import AgentDisplayConsole
+from rich.panel import Panel
+from rich.syntax import Syntax
+
+@pytest.fixture
+def console_display():
+    # Reset interactive_tool_calls to False by default for other tests if AgentDisplayConsole is used elsewhere
+    return AgentDisplayConsole(interactive_tool_calls=True)
+
+@pytest.mark.asyncio
+async def test_prompt_approve_directly(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    tool_args = {"param1": "value1"}
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input:
+
+        # Simulate Prompt.ask for action choice ("approve")
+        # Simulate Confirm.ask for final confirmation (True)
+        mock_to_thread.side_effect = [
+            "approve", # User chooses 'approve' action
+            True       # User confirms execution
+        ]
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, tool_args, tool_id)
+
+        assert result == {"name": tool_name, "args": tool_args, "approved": True}
+        # Check that Prompt.ask and Confirm.ask were called via asyncio.to_thread
+        assert mock_to_thread.call_count == 2
+        mock_wait_for_input.assert_not_called() # Not called if not editing
+
+@pytest.mark.asyncio
+async def test_prompt_cancel_action(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    tool_args = {"param1": "value1"}
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread:
+        # Simulate Prompt.ask for action choice ("cancel")
+        mock_to_thread.return_value = "cancel" # First call to Prompt.ask
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, tool_args, tool_id)
+
+        assert result == {"name": tool_name, "args": tool_args, "approved": False}
+        mock_to_thread.assert_called_once() # Only Prompt.ask for action, no Confirm.ask
+
+@pytest.mark.asyncio
+async def test_prompt_edit_then_approve(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    original_args = {"param1": "value1"}
+    modified_args_str = '{"param1": "edited_value", "param2": 42}'
+    modified_args_dict = {"param1": "edited_value", "param2": 42}
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input:
+
+        # Simulate Prompt.ask for action choice ("edit")
+        # Simulate user input for new JSON
+        # Simulate Confirm.ask for final confirmation (True)
+        mock_to_thread.side_effect = [
+            "edit", # User chooses 'edit' action
+            True    # User confirms execution of modified args
+        ]
+        # Simulate multi-line input for JSON
+        mock_wait_for_input.side_effect = [modified_args_str, EOFError]
+
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, original_args, tool_id)
+
+        assert result == {"name": tool_name, "args": modified_args_dict, "approved": True}
+        assert mock_to_thread.call_count == 2 # Prompt.ask for action, Confirm.ask for approval
+        mock_wait_for_input.assert_called()
+
+@pytest.mark.asyncio
+async def test_prompt_edit_invalid_json_then_approve_original(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    original_args = {"param1": "value1"}
+    invalid_json_str = '{"param1": "broken value"' # Missing closing brace
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input, \
+         patch.object(console_display.console, 'print') as mock_console_print: # To check error messages
+
+        mock_to_thread.side_effect = [
+            "edit", # User chooses 'edit' action
+            True    # User confirms execution (should be original args)
+        ]
+        mock_wait_for_input.side_effect = [invalid_json_str, EOFError]
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, original_args, tool_id)
+
+        assert result == {"name": tool_name, "args": original_args, "approved": True}
+        # Check that an error message about invalid JSON was printed
+        assert any("Invalid JSON" in call.args[0] for call in mock_console_print.call_args_list if call.args)
+
+
+@pytest.mark.asyncio
+async def test_prompt_edit_empty_json_then_approve_original(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    original_args = {"param1": "value1"}
+    empty_json_str = ''
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input, \
+         patch.object(console_display.console, 'print') as mock_console_print:
+
+        mock_to_thread.side_effect = [
+            "edit", # User chooses 'edit' action
+            True    # User confirms execution (should be original args)
+        ]
+        mock_wait_for_input.side_effect = [empty_json_str, EOFError]
+        # Also simulate empty lines if wait_for_user_input is called multiple times before EOF
+        # For this test, one call returning empty string then EOF is enough.
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, original_args, tool_id)
+
+        assert result == {"name": tool_name, "args": original_args, "approved": True}
+        assert any("No input received" in call.args[0] for call in mock_console_print.call_args_list if call.args)
+
+
+@pytest.mark.asyncio
+async def test_prompt_edit_then_reject(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    original_args = {"param1": "value1"}
+    modified_args_str = '{"param1": "edited_value"}'
+    modified_args_dict = {"param1": "edited_value"}
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input:
+
+        mock_to_thread.side_effect = [
+            "edit", # User chooses 'edit' action
+            False   # User then REJECTS execution
+        ]
+        mock_wait_for_input.side_effect = [modified_args_str, EOFError]
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, original_args, tool_id)
+
+        # Args should be the modified ones, but approved is False
+        assert result == {"name": tool_name, "args": modified_args_dict, "approved": False}
+
+@pytest.mark.asyncio
+async def test_prompt_edit_cancelled_with_keyboard_interrupt(console_display: AgentDisplayConsole):
+    tool_name = "test_tool"
+    original_args = {"param1": "value1"}
+    tool_id = "id_123"
+
+    with patch('asyncio.to_thread') as mock_to_thread, \
+         patch.object(console_display, 'wait_for_user_input', new_callable=AsyncMock) as mock_wait_for_input, \
+         patch.object(console_display.console, 'print') as mock_console_print:
+
+        mock_to_thread.side_effect = [
+            "edit", # User chooses 'edit' action
+            # No second call to mock_to_thread for Confirm.ask because KeyboardInterrupt should bypass it
+        ]
+        # Simulate KeyboardInterrupt during the first call to wait_for_user_input
+        mock_wait_for_input.side_effect = KeyboardInterrupt
+
+        result = await console_display.prompt_for_tool_call_approval(tool_name, original_args, tool_id)
+
+        # Should default to approving original parameters if edit is interrupted
+        assert result == {"name": tool_name, "args": original_args, "approved": True}
+        assert any("Edit cancelled" in call.args[0] for call in mock_console_print.call_args_list if call.args)
+        # Confirm.ask should not have been reached
+        assert mock_to_thread.call_count == 1 # Only for the initial "action" prompt

--- a/tests/utils/test_web_ui.py
+++ b/tests/utils/test_web_ui.py
@@ -1,0 +1,179 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from queue import Queue
+
+# Mock the config module before importing WebUI
+# This is to prevent issues with get_constant, set_constant etc. during WebUI init
+mock_config = MagicMock()
+mock_config.LOGS_DIR = "mock_logs"
+mock_config.PROMPTS_DIR = MagicMock()
+mock_config.PROMPTS_DIR.glob.return_value = []
+mock_config.PROMPTS_DIR.exists.return_value = True # Assume prompts dir exists
+mock_config.get_constant.return_value = "mock_value"
+
+# IMPORTANT: Patch 'config' module specifically for 'utils.web_ui' before it's imported by tests
+# Also patch tools if their import in WebUI __init__ is problematic
+# For now, let's try patching config and see.
+# If tools are an issue, they are imported lazily in WebUI, so might be okay for init.
+
+# Patch 'ftfy' as it's imported by utils.web_ui
+# If it's not a direct dependency of the tested method, this might not be strictly necessary
+# but good for isolating the WebUI class for testing.
+with patch.dict('sys.modules', {'config': mock_config, 'ftfy': MagicMock()}):
+    from utils.web_ui import WebUI
+
+
+@pytest.fixture
+def web_ui_instance():
+    # Mock agent_runner, which is called by WebUI
+    mock_agent_runner = AsyncMock()
+
+    # Path for Flask templates - adjust if your structure is different or mock render_template
+    # For unit testing prompt_for_tool_call_approval, Flask routes might not be directly hit.
+    with patch('utils.web_ui.Flask', MagicMock()) as mock_flask, \
+         patch('utils.web_ui.SocketIO', MagicMock()) as mock_socketio, \
+         patch('utils.web_ui.Path.mkdir'), \
+         patch('utils.web_ui.ToolCollection', MagicMock()): # Mock ToolCollection if its init is complex
+
+        ui = WebUI(agent_runner=mock_agent_runner, interactive_tool_calls=True)
+        # Replace the actual socketio instance with a MagicMock for easier testing of emits
+        ui.socketio = MagicMock()
+        ui.app = MagicMock() # Mock Flask app if needed for other parts, not strictly for this method
+        return ui
+
+@pytest.mark.asyncio
+async def test_web_prompt_approve(web_ui_instance: WebUI):
+    tool_name = "web_tool"
+    tool_args = {"data": "send"}
+    tool_id = "web_id_1"
+
+    # Store approval_request_id to simulate client sending it back
+    captured_emit_data = {}
+
+    def capture_emit(*args, **kwargs):
+        if args[0] == "request_tool_approval":
+            captured_emit_data.update(args[1])
+
+    web_ui_instance.socketio.emit.side_effect = capture_emit
+
+    async def simulate_client_response():
+        # Give a slight delay for the server to emit and set up the event
+        await asyncio.sleep(0.01)
+        request_id = captured_emit_data.get("approval_request_id")
+        assert request_id is not None
+        # Simulate the socketio handler being called
+        web_ui_instance.handle_tool_approval_response({
+            "approval_request_id": request_id,
+            "name": tool_name,
+            "args": tool_args,
+            "approved": True
+        })
+
+    # Run the method and the simulation concurrently
+    main_task = asyncio.create_task(web_ui_instance.prompt_for_tool_call_approval(tool_name, tool_args, tool_id))
+    client_sim_task = asyncio.create_task(simulate_client_response())
+
+    result = await main_task
+    await client_sim_task # ensure simulation completes
+
+    assert result == {"name": tool_name, "args": tool_args, "approved": True}
+    web_ui_instance.socketio.emit.assert_called_once_with(
+        "request_tool_approval",
+        {
+            "tool_name": tool_name,
+            "tool_args": tool_args,
+            "tool_id": tool_id,
+            "approval_request_id": captured_emit_data.get("approval_request_id") # Check it's the same id
+        }
+    )
+
+@pytest.mark.asyncio
+async def test_web_prompt_edit_and_approve(web_ui_instance: WebUI):
+    tool_name = "web_tool_edit"
+    original_args = {"data": "original"}
+    modified_args = {"data": "modified", "extra": True}
+    tool_id = "web_id_edit"
+
+    captured_emit_data = {}
+    def capture_emit(*args, **kwargs):
+        if args[0] == "request_tool_approval":
+            captured_emit_data.update(args[1])
+    web_ui_instance.socketio.emit.side_effect = capture_emit
+
+    async def simulate_client_response_edit():
+        await asyncio.sleep(0.01)
+        request_id = captured_emit_data.get("approval_request_id")
+        assert request_id is not None
+        web_ui_instance.handle_tool_approval_response({
+            "approval_request_id": request_id,
+            "name": tool_name, # Name could also be editable on client, assume same for this test
+            "args": modified_args, # Client sends back modified args
+            "approved": True
+        })
+
+    main_task = asyncio.create_task(web_ui_instance.prompt_for_tool_call_approval(tool_name, original_args, tool_id))
+    client_sim_task = asyncio.create_task(simulate_client_response_edit())
+    result = await main_task
+    await client_sim_task
+
+    assert result == {"name": tool_name, "args": modified_args, "approved": True}
+    assert captured_emit_data["tool_args"] == original_args # Ensure original args were sent
+
+@pytest.mark.asyncio
+async def test_web_prompt_reject(web_ui_instance: WebUI):
+    tool_name = "web_tool_reject"
+    tool_args = {"data": "reject_this"}
+    tool_id = "web_id_reject"
+
+    captured_emit_data = {}
+    def capture_emit(*args, **kwargs):
+        if args[0] == "request_tool_approval":
+            captured_emit_data.update(args[1])
+    web_ui_instance.socketio.emit.side_effect = capture_emit
+
+    async def simulate_client_response_reject():
+        await asyncio.sleep(0.01)
+        request_id = captured_emit_data.get("approval_request_id")
+        assert request_id is not None
+        web_ui_instance.handle_tool_approval_response({
+            "approval_request_id": request_id,
+            "name": tool_name,
+            "args": tool_args, # Args might be original or modified, doesn't matter much if rejected
+            "approved": False # Client rejects
+        })
+
+    main_task = asyncio.create_task(web_ui_instance.prompt_for_tool_call_approval(tool_name, tool_args, tool_id))
+    client_sim_task = asyncio.create_task(simulate_client_response_reject())
+    result = await main_task
+    await client_sim_task
+
+    assert result == {"name": tool_name, "args": tool_args, "approved": False}
+
+@pytest.mark.asyncio
+async def test_web_prompt_timeout(web_ui_instance: WebUI):
+    tool_name = "web_tool_timeout"
+    tool_args = {"data": "timeout_test"}
+    tool_id = "web_id_timeout"
+
+    # No client response will be simulated for timeout
+
+    # Patch the timeout value for faster testing
+    with patch('utils.web_ui.asyncio.wait_for') as mock_wait_for:
+        # Make wait_for raise TimeoutError immediately
+        mock_wait_for.side_effect = asyncio.TimeoutError
+
+        result = await web_ui_instance.prompt_for_tool_call_approval(tool_name, tool_args, tool_id)
+
+    assert result == {"name": tool_name, "args": tool_args, "approved": False, "error": "timeout"}
+    web_ui_instance.socketio.emit.assert_called_once() # Check that emit was attempted
+    # Ensure the event was added and then removed due to timeout
+    assert not web_ui_instance.tool_approval_events # Should be empty after timeout
+    assert not web_ui_instance.tool_approval_data
+
+# Note: To run these tests, you might need to ensure that the asyncio event loop
+# is properly managed, especially with pytest-asyncio.
+# The `handle_tool_approval_response` is synchronous but sets an asyncio.Event.
+# The way it's called in `simulate_client_response` should work fine with pytest-asyncio.
+# The patch for 'config' and 'ftfy' at the top is crucial.


### PR DESCRIPTION
This feature introduces a command-line flag `--interactive-tool-calls`. When enabled, the agent will pause before executing a tool, display the tool name and parameters, and allow the user to approve, edit, or cancel the call.

Changes include:
- Added `--interactive-tool-calls` flag to `run.py`.
- Modified `Agent.step()` to include the interactive approval flow.
- Implemented `prompt_for_tool_call_approval` methods in `AgentDisplayConsole` (using Rich for console UI) and `WebUI` (server-side logic using SocketIO for web UI).
- Added unit tests for the new functionality in the Agent, AgentDisplayConsole, and WebUI.
- Updated `README.md` to document the new feature.

## Summary by Sourcery

Implement an interactive inspection and modification flow for agent tool calls behind a new `--interactive-tool-calls` flag, add corresponding console and web UI prompts, integrate the approval logic into the agent runtime, and cover all scenarios with unit tests.

New Features:
- Add `--interactive-tool-calls` CLI flag to enable pausing before each tool execution for interactive approval or modification
- Implement interactive tool call approval prompts in the console UI using Rich
- Implement interactive tool call approval prompts in the web UI using SocketIO

Enhancements:
- Update `Agent.step()` to integrate the interactive approval flow, including handling of cancellations and argument edits
- Extend `AgentDisplayConsole` and `WebUI` constructors to accept the interactive flag and manage prompt state

Documentation:
- Update README with documentation for the `--interactive-tool-calls` option and its usage details

Tests:
- Add unit tests covering interactive tool call scenarios in the Agent, console UI, and web UI
- Include tests for approving, editing, cancelling, and timeout behaviors of tool call prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an interactive mode for tool calls, allowing users to approve, modify, or cancel tool executions before they run, available in both console and web interfaces via a new command-line flag.
  * Added user prompts for tool call approval, including editing parameters and handling cancellations.
  * Expanded documentation to describe the new interactive tool call feature and provide usage examples.

* **Tests**
  * Added comprehensive tests for interactive tool call approval workflows in both console and web interfaces, covering approval, editing, cancellation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->