### PR TITLE
Fix tool prompt modal bugs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -726,17 +726,21 @@
                 // Initialize with existing values
                 let arrayValue = Array.isArray(value) ? value : (value ? [value] : []);
                 
+                // Create a unique ID for this array field
+                const arrayId = 'array_' + Math.random().toString(36).substr(2, 9);
+                
                 function updateTags() {
                     tagsContainer.innerHTML = '';
                     arrayValue.forEach(function(item, index) {
                         const tag = document.createElement('span');
                         tag.className = 'array-tag';
-                        tag.innerHTML = escapeHtml(item) + '<span class="remove" onclick="removeArrayItem(' + index + ')">×</span>';
+                        tag.innerHTML = escapeHtml(item) + '<span class="remove" onclick="removeArrayItem_' + arrayId + '(' + index + ')">×</span>';
                         tagsContainer.appendChild(tag);
                     });
                 }
                 
-                window.removeArrayItem = function(index) {
+                // Create a unique function for this array field
+                window['removeArrayItem_' + arrayId] = function(index) {
                     arrayValue.splice(index, 1);
                     updateTags();
                 };
@@ -770,9 +774,9 @@
                 input.rows = info.type === 'string' && (value || '').length > 100 ? 4 : 2;
             }
             
-            if (input && info.type !== 'boolean') {
+            if (input && info.type !== 'array') {
                 input.name = param;
-                if (info.type !== 'array') {
+                if (info.type !== 'boolean') {
                     group.appendChild(input);
                 }
             }


### PR DESCRIPTION
Fix array field removal closure bug and ensure boolean inputs have `name` attributes in the tool prompt modal.

The `removeArrayItem` function was globally assigned, causing it to be overwritten each time an array input field was created. This resulted in all "remove" buttons incorrectly operating on the data of the *last* array field initialized due to a closure issue. The fix involves creating unique functions for each array field. Additionally, boolean input fields were not assigned a `name` attribute, preventing them from being correctly identified and included in form validation and submission.