### PR TITLE
Create exit button for graceful shutdown

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -508,6 +508,7 @@
             <textarea id="user_input" placeholder="Type your message here..."></textarea>
             <button onclick="sendMessage()">Send</button>
             <button onclick="interruptAgent()">Interrupt</button>
+            <button onclick="exitAgent()" style="margin-left:10px;">Exit</button>
         </div>
     </div>
 
@@ -633,6 +634,10 @@
 
         socket.on('tool_prompt_clear', function() {
             hideToolPrompt();
+        });
+
+        socket.on('server_shutdown', function(data) {
+            alert(data.message || 'Server is shutting down');
         });
 
         function getToolIcon(toolName) {
@@ -997,6 +1002,27 @@
         function interruptAgent() {
             socket.emit('interrupt');
             alert('Agent interruption requested.');
+        }
+
+        function exitAgent() {
+            if (confirm('Are you sure you want to shut down the server?')) {
+                fetch('/shutdown', { method: 'POST' })
+                    .then(response => {
+                        if (response.ok) {
+                            alert('Server shutting down...');
+                            // Optionally close the page after a short delay
+                            setTimeout(() => {
+                                window.close();
+                            }, 500);
+                        } else {
+                            alert('Failed to shut down the server.');
+                        }
+                    })
+                    .catch(err => {
+                        console.error(err);
+                        alert('Error sending shutdown request.');
+                    });
+            }
         }
 
         // Handle Enter key in textarea

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -194,6 +194,18 @@ class WebUI:
                 params=params,
                 result=result_text,
             )
+        @self.app.route("/shutdown", methods=["POST"])
+        def shutdown_route():
+            """Shut down the SocketIO server and exit the application gracefully."""
+            logging.info("Shutdown requested via /shutdown route")
+            # Notify connected clients first (optional)
+            try:
+                self.socketio.emit("server_shutdown", {"message": "Server is shutting down."})
+            except Exception as exc:
+                logging.error(f"Error emitting shutdown notice: {exc}")
+            # Stop the SocketIO server in a separate thread to avoid blocking the request context
+            threading.Thread(target=self.socketio.stop, daemon=True).start()
+            return "Server shutting down", 200
         logging.info("Routes set up")
 
     def setup_socketio_events(self):


### PR DESCRIPTION
Add an 'Exit' button to the web UI to gracefully shut down the agent server.

## Summary by Sourcery

Add a new Exit button and backend shutdown route to enable graceful shutdown of the agent server, with client notification and optional browser closing.

New Features:
- Add an 'Exit' button to the web UI for initiating a graceful shutdown
- Implement a POST /shutdown endpoint to trigger server shutdown and notify clients

Enhancements:
- Emit a 'server_shutdown' socket event to alert connected clients before shutting down
- Automatically close the browser window upon successful shutdown request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Exit" button to the user interface, allowing users to initiate server shutdown with confirmation.
  * Users receive alerts for server shutdown status and a notification when the server is shutting down.
* **Improvements**
  * Enhanced user feedback during server shutdown with real-time alerts and automatic window closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->