### PR TITLE
Remove redundant project directory references

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,9 +6,6 @@ import logging.handlers
 import sys
 import platform
 
-global PROJECT_DIR
-PROJECT_DIR = None
-
 # Load environment variables from .env file
 load_dotenv()
 
@@ -29,10 +26,10 @@ OS_NAME = platform.system()
 TOP_LEVEL_DIR = Path.cwd()
 WORKER_DIR = TOP_LEVEL_DIR # For worker processes, from load_constants.py
 
-# Define the repository directory based on PROJECT_DIR
+# Define the repository directory
 REPO_DIR = TOP_LEVEL_DIR / "repo"
 
-# Define other relevant paths based on PROJECT_DIR
+# Define other relevant paths
 SYSTEM_PROMPT_DIR = TOP_LEVEL_DIR / "system_prompt"
 SYSTEM_PROMPT_FILE = SYSTEM_PROMPT_DIR / "system_prompt.md"
 BASH_PROMPT_DIR = TOP_LEVEL_DIR / "tools"
@@ -163,7 +160,6 @@ def write_constants_to_file():
         "PROMPT_CACHING_BETA_FLAG": PROMPT_CACHING_BETA_FLAG,
         "MAX_SUMMARY_MESSAGES": MAX_SUMMARY_MESSAGES,
         "MAX_SUMMARY_TOKENS": MAX_SUMMARY_TOKENS,
-        "PROJECT_DIR": str(PROJECT_DIR) if PROJECT_DIR else "",
         "PROMPT_NAME": PROMPT_NAME if PROMPT_NAME else "",
         "TASK": "NOT YET CREATED", # Default task, can be updated by set_constant
     }
@@ -222,7 +218,7 @@ def set_constant(name: str, value: Any):
     # So, if we want set_constant to be robust for *any* key, we might need to update globals first,
     # or make write_constants_to_file accept a dictionary.
 
-    # Update the global variable if it exists (e.g. PROJECT_DIR, MAIN_MODEL etc.)
+    # Update the global variable if it exists (e.g. REPO_DIR, MAIN_MODEL etc.)
     # This makes the change immediately available to the current session.
     if name in globals():
         globals()[name] = value
@@ -231,11 +227,6 @@ def set_constant(name: str, value: Any):
         json.dump(constants, f, indent=4)
     logging.info(f"Constant '{name}' set to '{value}' and persisted.")
     return True
-
-
-# Function to get the project directory
-def get_project_dir():
-    return PROJECT_DIR
 
 
 def write_to_file(s: str, file_path: Path): # Modified to take Path object

--- a/tools/bash.py
+++ b/tools/bash.py
@@ -121,9 +121,9 @@ class BashTool(BaseTool):
         success = False
         cwd = None
         try:
-            # Execute the command locally relative to PROJECT_DIR if set
-            project_dir = get_constant("PROJECT_DIR")
-            cwd = str(project_dir) if project_dir else None
+            # Execute the command locally relative to REPO_DIR if set
+            repo_dir = get_constant("REPO_DIR")
+            cwd = str(repo_dir) if repo_dir else None
             terminal_display = f"terminal {cwd}>  {command}"
             if self.display is not None:
                 self.display.add_message("assistant", terminal_display)

--- a/tools/edit.py
+++ b/tools/edit.py
@@ -51,12 +51,12 @@ class EditTool(BaseTool):
         self._file_history = defaultdict(list)
 
     def _resolve_path(self, path: str | Path) -> Path:
-        """Resolve a given path relative to PROJECT_DIR if not absolute, and normalize it."""
+        """Resolve a given path relative to REPO_DIR if not absolute, and normalize it."""
         p = Path(path)
         if not p.is_absolute():
-            project_dir = get_constant("PROJECT_DIR")
-            if project_dir:
-                p = Path(project_dir) / p
+            repo_dir = get_constant("REPO_DIR")
+            if repo_dir:
+                p = Path(repo_dir) / p
         return p.resolve()
 
     def to_params(self) -> dict:
@@ -143,7 +143,7 @@ class EditTool(BaseTool):
                     "user", f"EditTool Executing Command: {command} on path: {path}"
                 )
 
-            # Normalize the path first relative to PROJECT_DIR
+            # Normalize the path first relative to REPO_DIR
             _path = self._resolve_path(path)
             if command == "create":
                 if not file_text:

--- a/utils/agent_display_console.py
+++ b/utils/agent_display_console.py
@@ -101,7 +101,6 @@ class AgentDisplayConsole:
         repo_dir = base_repo_dir / prompt_name
         repo_dir.mkdir(parents=True, exist_ok=True)
         set_prompt_name(prompt_name)
-        set_constant("PROJECT_DIR", repo_dir)
         set_constant("REPO_DIR", repo_dir)
         write_constants_to_file()
 

--- a/utils/file_logger.py
+++ b/utils/file_logger.py
@@ -39,7 +39,7 @@ except ImportError:
     def get_constant(name):
         # Default values for essential constants
         defaults = {
-            "PROJECT_DIR": os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "TOP_LEVEL_DIR": os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             "LOG_FILE": os.path.join(
                 os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                 "logs",

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -115,7 +115,6 @@ class WebUI:
             repo_dir = base_repo_dir / prompt_name
             repo_dir.mkdir(parents=True, exist_ok=True)
             set_prompt_name(prompt_name)
-            set_constant("PROJECT_DIR", repo_dir)
             set_constant("REPO_DIR", repo_dir)
             write_constants_to_file()
             


### PR DESCRIPTION
Remove redundant `PROJECT_DIR` and `project_dir` concepts to simplify directory management.