### PR TITLE
Add OpenInterpreter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Slaze is an experimental agent that can generate code, set up projects and execu
 - Interactive prompt creation: you can edit existing prompt files or create a new one on launch.
 - New prompts may be sent to the LLM for analysis to generate an expanded task definition when an
   `OPENROUTER_API_KEY` is available.
-- Tools include `WriteCodeTool`, `ProjectSetupTool`, `BashTool`, `DockerEditTool` and
-  `PictureGenerationTool` for generating files and images inside a Docker container.
+- Tools include `WriteCodeTool`, `ProjectSetupTool`, `BashTool`, `DockerEditTool`,
+  `OpenInterpreterTool` and `PictureGenerationTool` for generating files and images inside a Docker container.
 - Tool execution results are logged to `logs/tool.log` and `logs/tool.txt` for later review.
 
 ## Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,3 +110,4 @@ wsproto==1.2.0
 yarl==1.20.1
 zope-event==5.0
 zope-interface==7.2
+open-interpreter==0.4.3

--- a/test_unicode.py
+++ b/test_unicode.py
@@ -23,6 +23,10 @@ def test_unicode_output():
     
     return True
 
+import pytest
+
+
+@pytest.mark.asyncio
 async def test_bash_tool_unicode():
     """Test BashTool with Unicode output."""
     print("\n=== BashTool Unicode Test ===")

--- a/tests/tools/test_open_interpreter.py
+++ b/tests/tools/test_open_interpreter.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.open_interpreter_tool import OpenInterpreterTool
+from tools.base import ToolResult, ToolError
+
+
+@pytest.fixture
+def oi_tool():
+    return OpenInterpreterTool()
+
+
+@pytest.mark.asyncio
+async def test_basic_instruction_execution(oi_tool):
+    with patch('tools.open_interpreter_tool.interpreter.chat', return_value='done'):
+        result = await oi_tool("list files")
+
+    assert isinstance(result, ToolResult)
+    assert result.output == 'done'
+    assert result.tool_name == "open_interpreter"
+    assert result.command == "list files"
+
+
+@pytest.mark.asyncio
+async def test_no_instruction_provided(oi_tool):
+    with pytest.raises(ToolError):
+        await oi_tool()
+
+
+@pytest.mark.asyncio
+async def test_display_integration(oi_tool):
+    mock_display = MagicMock()
+    oi_tool.display = mock_display
+    with patch('tools.open_interpreter_tool.interpreter.chat', return_value='ok'):
+        result = await oi_tool("check version")
+
+    assert isinstance(result, ToolResult)
+    mock_display.add_message.assert_called_with("user", "Executing instruction: check version")
+

--- a/tests/web/test_toolbox.py
+++ b/tests/web/test_toolbox.py
@@ -13,9 +13,20 @@ def test_tools_page(client):
     assert resp.status_code == 200
     # basic check for at least one tool name in response
     assert b'bash' in resp.data
+    assert b'open_interpreter' in resp.data
 
 
 def test_run_bash_tool(client):
     resp = client.post('/tools/bash', data={'command': 'echo test'})
     assert resp.status_code == 200
     assert b'test' in resp.data
+
+
+def test_run_open_interpreter_tool(client, monkeypatch):
+    monkeypatch.setattr(
+        'tools.open_interpreter_tool.interpreter.chat',
+        lambda instruction: 'oi_result',
+    )
+    resp = client.post('/tools/open_interpreter', data={'instruction': 'list'})
+    assert resp.status_code == 200
+    assert b'oi_result' in resp.data

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -12,8 +12,9 @@ from .envsetup import ProjectSetupTool
 
 # from .test_navigation_tool import windows_navigate
 from .write_code import WriteCodeTool
-from .create_picture import PictureGenerationTool
 # from .file_editor import FileEditorTool # Removed
+from .create_picture import PictureGenerationTool
+from .open_interpreter_tool import OpenInterpreterTool
 
 __all__ = [
     "BaseAnthropicTool",
@@ -30,6 +31,7 @@ __all__ = [
     # "WindowsNavigationTool", # Removed
     "WriteCodeTool",
     "PictureGenerationTool",
+    "OpenInterpreterTool",
     # "windows_navigate",
     # "FileEditorTool", # Removed
 ]

--- a/tools/open_interpreter_tool.py
+++ b/tools/open_interpreter_tool.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+from typing import ClassVar, Literal, Union
+
+from interpreter import interpreter
+
+from .base import BaseTool, ToolError, ToolResult
+from utils.web_ui import WebUI
+from utils.agent_display_console import AgentDisplayConsole
+
+
+class OpenInterpreterTool(BaseTool):
+    """Execute natural language instructions using open-interpreter."""
+
+    name: ClassVar[Literal["open_interpreter"]] = "open_interpreter"
+    api_type: ClassVar[Literal["open_interpreter_20250124"]] = "open_interpreter_20250124"
+
+    description = (
+        "A tool that uses open-interpreter to execute natural language instructions."
+    )
+
+    def __init__(self, display: Union[WebUI, AgentDisplayConsole] | None = None):
+        self.display = display
+        super().__init__(input_schema=None, display=display)
+
+    async def __call__(self, instruction: str | None = None, **_: object) -> ToolResult:
+        """Run open-interpreter with the given instruction."""
+        if instruction is None:
+            raise ToolError("no instruction provided.")
+
+        if self.display is not None:
+            try:
+                self.display.add_message("user", f"Executing instruction: {instruction}")
+            except Exception as exc:
+                return ToolResult(error=str(exc), tool_name=self.name, command=instruction)
+
+        try:
+            result = await asyncio.to_thread(interpreter.chat, instruction)
+            output = result if isinstance(result, str) else str(result)
+            return ToolResult(output=output, tool_name=self.name, command=instruction)
+        except Exception as exc:
+            return ToolResult(error=str(exc), tool_name=self.name, command=instruction)
+
+    def to_params(self) -> dict:
+        params = {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "instruction": {
+                            "type": "string",
+                            "description": "Natural language instruction to execute.",
+                        }
+                    },
+                    "required": ["instruction"],
+                },
+            },
+        }
+        return params

--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -58,6 +58,7 @@ class WebUI:
             WriteCodeTool,
             PictureGenerationTool,
             EditTool,
+            OpenInterpreterTool,
             ToolCollection,
         )
 
@@ -67,6 +68,7 @@ class WebUI:
             BashTool(display=self),
             PictureGenerationTool(display=self),
             EditTool(display=self),
+            OpenInterpreterTool(display=self),
             display=self,
         )
         self.setup_routes()


### PR DESCRIPTION
## Summary
- implement `OpenInterpreterTool` that uses `interpreter.chat`
- register the tool in `tools/__init__` and the web UI
- add tests for the new tool and update toolbox tests
- include open-interpreter dependency
- document the tool in the README
- fix unicode test async marker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871805c1e788331be203332a8a3cae5

## Summary by Sourcery

Add OpenInterpreterTool and integrate it into the tool registry, web UI, documentation, and tests.

New Features:
- Introduce OpenInterpreterTool for executing natural language instructions via open-interpreter.

Enhancements:
- Register the new tool in the tools registry and expose it in the web UI toolbox endpoint.

Build:
- Add open-interpreter dependency to requirements.txt.

Documentation:
- Document the new OpenInterpreterTool in the README.

Tests:
- Add unit and integration tests for OpenInterpreterTool, update toolbox tests to include the new tool, and fix async marker in the unicode test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the OpenInterpreter tool, enabling execution of natural language instructions via the web interface.

* **Documentation**
  * Updated the README to include OpenInterpreter in the list of available tools.

* **Tests**
  * Added comprehensive tests for OpenInterpreter, covering instruction execution, error handling, and web integration.
  * Enhanced web tool tests to verify OpenInterpreter’s presence and correct operation.

* **Chores**
  * Added the open-interpreter package as a dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->