### PR TITLE
Add OpenInterpreter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Slaze is an experimental agent that can generate code, set up projects and execu
 - New prompts may be sent to the LLM for analysis to generate an expanded task definition when an
   `OPENROUTER_API_KEY` is available.
 - Tools include `WriteCodeTool`, `ProjectSetupTool`, `BashTool`, `DockerEditTool` and
-  `PictureGenerationTool` for generating files and images inside a Docker container.
+  `PictureGenerationTool`, and `OpenInterpreterTool` for generating files and images inside a Docker container.
 - Tool execution results are logged to `logs/tool.log` and `logs/tool.txt` for later review.
 
 ## Installation

--- a/agent.py
+++ b/agent.py
@@ -11,6 +11,7 @@ from rich import print as rr
 
 from tools import (
     BashTool,
+    OpenInterpreterTool,
     ProjectSetupTool,
     WriteCodeTool,
     PictureGenerationTool,
@@ -184,6 +185,7 @@ class Agent:
             WriteCodeTool(display=self.display),
             ProjectSetupTool(display=self.display),
             BashTool(display=self.display),
+            OpenInterpreterTool(display=self.display),
             PictureGenerationTool(display=self.display),
             EditTool(display=self.display),  # Uncommented and enabled for testing
             display=self.display,

--- a/tests/tools/test_open_interpreter_tool.py
+++ b/tests/tools/test_open_interpreter_tool.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.open_interpreter_tool import OpenInterpreterTool
+from tools.base import ToolResult, ToolError
+
+@pytest.fixture
+def interpreter_tool():
+    return OpenInterpreterTool()
+
+@pytest.mark.asyncio
+async def test_call_success(interpreter_tool):
+    with patch('tools.open_interpreter_tool.interpreter') as mock_interp:
+        mock_interp.chat.return_value = 'ok'
+        mock_chat = mock_interp.chat
+        result = await interpreter_tool('print(1)')
+    assert isinstance(result, ToolResult)
+    assert result.output == 'ok'
+    assert result.tool_name == 'open_interpreter'
+    assert result.command == 'print(1)'
+    mock_chat.assert_called_with('print(1)', display=False, stream=False, blocking=True)
+
+@pytest.mark.asyncio
+async def test_no_message(interpreter_tool):
+    with pytest.raises(ToolError):
+        await interpreter_tool()
+
+@pytest.mark.asyncio
+async def test_display_error(interpreter_tool):
+    mock_display = MagicMock()
+    mock_display.add_message.side_effect = Exception('fail')
+    interpreter_tool.display = mock_display
+    with patch('tools.open_interpreter_tool.interpreter') as mock_interp:
+        mock_interp.chat.return_value = 'ok'
+        result = await interpreter_tool('cmd')
+    assert result.error == 'fail'
+
+@pytest.mark.asyncio
+async def test_chat_exception(interpreter_tool):
+    with patch('tools.open_interpreter_tool.interpreter') as mock_interp:
+        mock_interp.chat.side_effect = Exception('boom')
+        result = await interpreter_tool('cmd')
+    assert result.error == 'boom'

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,6 +13,7 @@ from .envsetup import ProjectSetupTool
 # from .test_navigation_tool import windows_navigate
 from .write_code import WriteCodeTool
 from .create_picture import PictureGenerationTool
+from .open_interpreter_tool import OpenInterpreterTool
 # from .file_editor import FileEditorTool # Removed
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     # "WindowsNavigationTool", # Removed
     "WriteCodeTool",
     "PictureGenerationTool",
+    "OpenInterpreterTool",
     # "windows_navigate",
     # "FileEditorTool", # Removed
 ]

--- a/tools/open_interpreter_tool.py
+++ b/tools/open_interpreter_tool.py
@@ -1,0 +1,54 @@
+from typing import ClassVar, Literal, Union
+import logging
+try:
+    from interpreter import interpreter
+except Exception:  # pragma: no cover - optional dependency
+    interpreter = None
+
+from .base import BaseTool, ToolError, ToolResult
+from utils.web_ui import WebUI
+from utils.agent_display_console import AgentDisplayConsole
+
+logger = logging.getLogger(__name__)
+
+class OpenInterpreterTool(BaseTool):
+    """Execute commands using the open-interpreter package."""
+
+    name: ClassVar[Literal["open_interpreter"]] = "open_interpreter"
+    api_type: ClassVar[Literal["open_interpreter_20250124"]] = "open_interpreter_20250124"
+    description: str = (
+        "Runs instructions using open-interpreter's interpreter.chat function."
+    )
+
+    def __init__(self, display: Union[WebUI, AgentDisplayConsole] = None):
+        super().__init__(input_schema=None, display=display)
+
+    async def __call__(self, message: str | None = None, **kwargs):
+        if message is None:
+            raise ToolError("no message provided")
+
+        if self.display is not None:
+            try:
+                self.display.add_message("user", f"Interpreter request: {message}")
+            except Exception as e:
+                return ToolResult(error=str(e), tool_name=self.name, command=message)
+
+        try:
+            global interpreter
+            if interpreter is None:
+                from interpreter import interpreter as _interp
+                interpreter = _interp
+            result = interpreter.chat(message, display=False, stream=False, blocking=True)
+            return ToolResult(
+                output=str(result),
+                tool_name=self.name,
+                command=message,
+            )
+        except Exception as e:
+            logger.error("Interpreter execution failed", exc_info=True)
+            return ToolResult(
+                output="",
+                error=str(e),
+                tool_name=self.name,
+                command=message,
+            )


### PR DESCRIPTION
## Summary
- add new OpenInterpreterTool
- register it with tool collection and README
- test the new tool

## Testing
- `PYTHONPATH=. pytest tests/tools/test_open_interpreter_tool.py -q`
- `PYTHONPATH=. pytest -q` *(fails: test_unicode.py::test_bash_tool_unicode, tests/tools/test_write_code.py::TestWriteCodeTool::test_invalid_files_format, tests/tools/test_write_code.py::TestWriteCodeTool::test_extract_code_block, tests/utils/test_command_converter.py::test_command_converter_init, tests/utils/test_command_converter.py::test_global_convert_function, tests/web/test_toolbox.py::test_run_bash_tool)*

------
https://chatgpt.com/codex/tasks/task_e_6871805c1e788331be203332a8a3cae5