### PR TITLE
Fix markdown rendering for console blocks

### DIFF
--- a/console_markdown_fix.md
+++ b/console_markdown_fix.md
@@ -1,0 +1,64 @@
+# Console Markdown Block Rendering Fix
+
+## Issue Description
+The envsetup tool was passing console markdown blocks to the display assistant, but these blocks were not being rendered as code blocks on the webpage. Instead, they were being displayed as plain text due to HTML escaping.
+
+## Root Cause
+The issue was in `templates/index.html` where assistant messages were being processed with `escapeHtml(msg)` instead of parsing markdown:
+
+```javascript
+// Before (line 754):
+assistantMessagesDiv.innerHTML += '<div class="message assistant-message">' + escapeHtml(msg) + '</div>';
+
+// After:
+assistantMessagesDiv.innerHTML += '<div class="message assistant-message">' + parseMarkdown(msg) + '</div>';
+```
+
+## Solution Implementation
+
+### 1. Added Markdown and Syntax Highlighting Libraries
+Added the following CDN links to the HTML head:
+- `marked.js` - for markdown parsing
+- `prism.js` - for syntax highlighting  
+- `prism-bash.js` - for bash/shell highlighting
+- `prism-shell-session.js` - for shell session highlighting
+- `prism.css` - for syntax highlighting styles
+
+### 2. Created Markdown Parser Function
+Added `parseMarkdown()` function that:
+- Handles type conversion (similar to `escapeHtml`)
+- Configures marked.js to use Prism for syntax highlighting
+- Maps `console` language to `shell-session` or `bash` highlighting
+- Returns properly formatted HTML
+
+### 3. Updated Assistant Message Handling
+Changed assistant message processing from HTML escaping to markdown parsing.
+
+### 4. Added CSS Styles
+Added comprehensive CSS styles for:
+- Code blocks (`<pre>` and `<code>`)
+- Syntax highlighting themes
+- Console/shell-specific styling with dark theme
+- Proper typography and spacing
+
+### 5. Added Dynamic Re-highlighting
+Added `Prism.highlightAll()` call after message updates to ensure syntax highlighting is applied to dynamically inserted content.
+
+## Files Modified
+- `templates/index.html` - Updated JavaScript and CSS for markdown rendering
+
+## Expected Behavior
+Console markdown blocks from envsetup (like `\`\`\`console ... \`\`\``) should now render as properly formatted and syntax-highlighted code blocks on the webpage instead of plain text.
+
+## Example
+Console blocks like this from envsetup:
+```
+```console
+$ cd /workspace
+$ python -m venv venv
+$ source venv/bin/activate
+[Exit code: 0]
+```
+```
+
+Should now render as dark-themed, syntax-highlighted code blocks with proper shell/console formatting.

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Slazy Agent</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.0/socket.io.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-shell-session.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet" />
     <style>
         * {
             box-sizing: border-box;
@@ -190,6 +195,47 @@
             font-size: 13px;
             margin-right: 10%;
             border-left: 4px solid #ff9800;
+        }
+        
+        /* Code block styles for markdown rendering */
+        .message pre {
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 8px;
+            padding: 12px;
+            overflow-x: auto;
+            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+            font-size: 14px;
+            line-height: 1.4;
+            margin: 12px 0;
+        }
+        
+        .message code {
+            background: #f8f9fa;
+            border-radius: 4px;
+            padding: 2px 6px;
+            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+            font-size: 13px;
+        }
+        
+        .message pre code {
+            background: transparent;
+            padding: 0;
+            border-radius: 0;
+        }
+        
+        /* Console/shell syntax highlighting */
+        .message pre[class*="language-"] {
+            background: #2d3748;
+            color: #e2e8f0;
+            border: none;
+        }
+        
+        .message pre[class*="language-console"],
+        .message pre[class*="language-shell-session"],
+        .message pre[class*="language-bash"] {
+            background: #1a202c;
+            color: #e2e8f0;
         }
         
         .empty-state {
@@ -752,7 +798,7 @@
                 assistantMessagesDiv.innerHTML = '<div class="empty-state">No assistant messages yet</div>';
             } else {
                 data.assistant.forEach(function(msg) {
-                    assistantMessagesDiv.innerHTML += '<div class="message assistant-message">' + escapeHtml(msg) + '</div>';
+                    assistantMessagesDiv.innerHTML += '<div class="message assistant-message">' + parseMarkdown(msg) + '</div>';
                 });
             }
             
@@ -779,6 +825,11 @@
             if (currentMessagesDiv) {
                 currentMessagesDiv.scrollTop = currentMessagesDiv.scrollHeight;
             }
+            
+            // Re-highlight code blocks
+            if (typeof Prism !== 'undefined') {
+                Prism.highlightAll();
+            }
         }
 
         function escapeHtml(text) {
@@ -801,6 +852,39 @@
                 "'": '&#039;'
             };
             return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+        }
+
+        function parseMarkdown(text) {
+            // Convert non-string values to string first
+            if (typeof text !== 'string') {
+                if (text === null || text === undefined) {
+                    text = '';
+                } else if (typeof text === 'object') {
+                    text = JSON.stringify(text);
+                } else {
+                    text = String(text);
+                }
+            }
+            
+            // Configure marked to support console language highlighting
+            marked.setOptions({
+                highlight: function(code, lang) {
+                    if (lang && Prism.languages[lang]) {
+                        return Prism.highlight(code, Prism.languages[lang], lang);
+                    }
+                    // For console blocks, use shell-session highlighting if available
+                    if (lang === 'console' && Prism.languages['shell-session']) {
+                        return Prism.highlight(code, Prism.languages['shell-session'], 'shell-session');
+                    }
+                    // Fall back to bash highlighting for console blocks
+                    if (lang === 'console' && Prism.languages['bash']) {
+                        return Prism.highlight(code, Prism.languages['bash'], 'bash');
+                    }
+                    return code;
+                }
+            });
+            
+            return marked.parse(text);
         }
 
         socket.on('update', function(data) {


### PR DESCRIPTION
Enable markdown rendering and syntax highlighting for assistant messages to correctly display console code blocks.

Previously, assistant messages were HTML-escaped, causing markdown console blocks to appear as plain text instead of formatted code blocks. This PR integrates `marked.js` and `prism.js` to parse markdown and apply syntax highlighting, ensuring proper rendering.

## Summary by Sourcery

Enable markdown parsing and syntax highlighting for assistant messages using marked.js and Prism.js, fixing console code block rendering and adding appropriate styling.

Bug Fixes:
- Render console markdown blocks as syntax-highlighted code instead of plain text

Enhancements:
- Integrate marked.js and Prism.js for markdown parsing and syntax highlighting
- Add parseMarkdown function to convert messages and map console language to shell-session/bash highlighting
- Include CSS styles for fenced code blocks and console-specific dark theme
- Invoke Prism.highlightAll() after dynamic message insertion to apply highlighting

Documentation:
- Add console_markdown_fix.md documenting the rendering issue and solution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant messages now support rich Markdown rendering, including syntax-highlighted code blocks for console and shell output.
  * Enhanced visual styling for code blocks and console output with a dark theme and improved typography.

* **Bug Fixes**
  * Resolved an issue where console markdown blocks were displayed as plain text instead of formatted code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->