### PR TITLE
Improve message formatting to include tool info

### DIFF
--- a/tests/utils/test_context_helpers.py
+++ b/tests/utils/test_context_helpers.py
@@ -1,0 +1,42 @@
+import json
+import types
+from utils.context_helpers import format_messages_to_string
+
+
+def test_format_messages_to_string_basic():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+    ]
+    result = format_messages_to_string(messages)
+    assert "USER:" in result
+    assert "hello" in result
+    assert "ASSISTANT:" in result
+    assert "hi" in result
+
+
+def test_format_messages_with_tool_calls_and_results():
+    tc = types.SimpleNamespace()
+    tc.function = types.SimpleNamespace(name="echo", arguments=json.dumps({"a": 1}))
+    tc.id = "tid"
+    messages = [
+        {"role": "assistant", "content": None, "tool_calls": [tc]},
+        {
+            "role": "tool",
+            "tool_call_id": "tid",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tid",
+                    "is_error": False,
+                    "content": [{"type": "text", "text": "done"}],
+                }
+            ],
+        },
+    ]
+    result = format_messages_to_string(messages)
+    assert "Tool Call -> echo" in result
+    assert "Arguments" in result
+    assert "Tool Call ID: tid" in result
+    assert "Tool Result" in result
+    assert "done" in result

--- a/tools/open_interpreter_tool.py
+++ b/tools/open_interpreter_tool.py
@@ -10,7 +10,10 @@ import os
 import subprocess
 from pathlib import Path
 
-from interpreter import OpenInterpreter
+try:
+    from interpreter import OpenInterpreter
+except Exception:  # pragma: no cover - optional dependency
+    OpenInterpreter = None
 
 from config import get_constant, openai41
 from tools.base import BaseTool, ToolError, ToolResult


### PR DESCRIPTION
## Summary
- enhance `format_messages_to_string` with richer handling of text, tool calls and results
- allow `OpenInterpreterTool` to load without optional dependency
- add tests for message formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687946a313808331a64629d4bf2e852d

## Summary by Sourcery

Enhance the message formatting helper to include detailed tool call and result information, allow optional loading of the OpenInterpreterTool, and add unit tests for the new formatting behaviors.

New Features:
- Include tool call identifiers, function names, and arguments in the formatted message output
- Support formatting of diverse content block types (text, image, tool use, tool result) with error flag handling

Enhancements:
- Improve handling of missing or nested fields with a helper accessor
- Allow OpenInterpreterTool to load without requiring its optional dependency

Tests:
- Add unit tests for basic message formatting
- Add tests for tool call and tool result formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced message formatting provides more detailed and readable output, including tool call and result information.
* **Bug Fixes**
  * Improved import handling to prevent errors if certain dependencies are unavailable.
* **Tests**
  * Added tests to verify correct formatting of messages, including cases with tool calls and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->