### PR TITLE
Add VS Code style repo browser page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,6 @@ reportIncompatibleMethodOverride = false
 reportGeneralTypeIssues = false
 reportAttributeAccessIssue = false
 reportArgumentType = false
+
+[tool.uv.workspace]
+members = ["repo/graphingCalc"]

--- a/templates/vscode_view.html
+++ b/templates/vscode_view.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Repository Viewer</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <style>
+        body, html { margin:0; height:100%; font-family: Arial, sans-serif; }
+        .layout { display:flex; height:100vh; }
+        .sidebar { background:#1e1e1e; color:#ccc; overflow:auto; }
+        .primary { width:250px; }
+        .secondary { width:300px; }
+        .main { flex:1; display:flex; flex-direction:column; }
+        #editor { flex:1; padding:10px; background:#1e1e1e; color:#fff; overflow:auto; font-family:Menlo, monospace; }
+        #assistant-panel { height:200px; overflow:auto; border-top:1px solid #333; padding:10px; background:#111; }
+        #assistant-panel .message, #user-panel .message { white-space:pre-wrap; margin-bottom:10px; }
+        ul.tree { list-style:none; padding-left:20px; }
+        ul.tree li { cursor:pointer; }
+    </style>
+</head>
+<body>
+<div class="layout">
+    <div class="sidebar primary">
+        <ul id="file-tree" class="tree"></ul>
+    </div>
+    <div class="main">
+        <pre id="editor"></pre>
+        <div id="assistant-panel"></div>
+    </div>
+    <div class="sidebar secondary">
+        <div id="user-panel"></div>
+    </div>
+</div>
+<script>
+function fetchFileTree(){
+    fetch('/api/file_tree').then(r=>r.json()).then(buildTree);
+}
+function buildTree(paths){
+    const root={};
+    paths.forEach(p=>{
+        const parts=p.split('/');
+        let cur=root;
+        parts.forEach((pt,i)=>{
+            cur[pt]=cur[pt]||{};
+            if(i===parts.length-1) cur[pt].__path=p;
+            cur=cur[pt];
+        });
+    });
+    const rootEl=document.getElementById('file-tree');
+    rootEl.innerHTML='';
+    function create(el,obj){
+        Object.keys(obj).sort().forEach(name=>{
+            if(name==='__path') return;
+            const li=document.createElement('li');
+            li.textContent=name;
+            if(obj[name].__path) li.dataset.path=obj[name].__path;
+            const children=Object.keys(obj[name]).filter(k=>k!=='__path');
+            if(children.length){
+                const ul=document.createElement('ul');
+                create(ul,obj[name]);
+                li.appendChild(ul);
+            }
+            el.appendChild(li);
+        });
+    }
+    create(rootEl,root);
+}
+
+document.getElementById('file-tree').addEventListener('click',e=>{
+    const path=e.target.dataset.path;
+    if(path){
+        fetch('/api/file?path='+encodeURIComponent(path)).then(r=>r.json()).then(d=>{
+            document.getElementById('editor').textContent=d.content||'';
+        });
+    }
+});
+
+function loadMessages(){
+    fetch('/messages').then(r=>r.json()).then(d=>{
+        const assist=document.getElementById('assistant-panel');
+        assist.innerHTML='';
+        d.assistant.forEach(m=>{ assist.innerHTML += '<div class="message">'+marked.parse(m)+'</div>'; });
+        const user=document.getElementById('user-panel');
+        user.innerHTML='';
+        d.user.forEach(m=>{ user.innerHTML += '<div class="message">'+marked.parse(m)+'</div>'; });
+        Prism.highlightAll();
+    });
+}
+fetchFileTree();
+loadMessages();
+setInterval(loadMessages,2000);
+</script>
+</body>
+</html>

--- a/tests/web/test_repo_browser.py
+++ b/tests/web/test_repo_browser.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+import pytest
+from utils.web_ui import WebUI
+from config import set_constant
+
+@pytest.fixture
+def client(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.txt").write_text("hello")
+    (repo / "sub").mkdir()
+    (repo / "sub" / "b.txt").write_text("world")
+    set_constant("REPO_DIR", repo)
+    ui = WebUI(lambda *a, **k: None)
+    ui.app.testing = True
+    return ui.app.test_client()
+
+
+def test_file_tree_endpoint(client):
+    resp = client.get('/api/file_tree')
+    assert resp.status_code == 200
+    files = json.loads(resp.data)
+    assert 'a.txt' in files
+    assert 'sub/b.txt' in files
+
+
+def test_get_file_content(client):
+    resp = client.get('/api/file?path=a.txt')
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert data['content'] == 'hello'
+
+
+def test_vscode_page(client):
+    resp = client.get('/vscode')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add new optional `vscode` page that mimics VS Code layout
- show repository tree, user messages, and assistant log
- expose `/api/file_tree` and `/api/file` endpoints
- test new repo browser endpoints

## Testing
- `PYTHONPATH=. pytest tests/web/test_repo_browser.py -q`
- `pytest` *(fails: CommandConverter tests)*

------
https://chatgpt.com/codex/tasks/task_e_68802490fb1483319639310f0c069ea3

## Summary by Sourcery

Add a VS Code–style repository browser page with API endpoints to list and fetch files and integrate live display of file contents and chat messages

New Features:
- Introduce /vscode route and corresponding vscode_view.html template for a VS Code–like repo browser UI
- Implement /api/file_tree endpoint to return the repository file list
- Implement /api/file endpoint with path sanitization to return file contents

Tests:
- Add tests for the file tree and file content endpoints and for serving the VS Code browser page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a web-based repository viewer with a VS Code-style interface, allowing users to browse files and view their contents directly in the browser.
  * Added a dynamic file tree and code editor panel with syntax highlighting and markdown rendering for messages.
  * Implemented automatic message updates and improved user interaction with file selection.

* **Bug Fixes**
  * Improved error handling for invalid or inaccessible file paths in the repository browser.

* **Tests**
  * Added integration tests to verify file tree retrieval, file content access, and page loading for the repository viewer interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->