### PR TITLE
Restore tool parameter editing in web UI

### DIFF
--- a/templates/web_ide.html
+++ b/templates/web_ide.html
@@ -537,6 +537,262 @@
             return text.replace(/[&<>"']/g, function(m) { return map[m]; });
         }
 
+        let currentToolData = null;
+
+        function getToolDescription(toolName, schema) {
+            if (schema && schema.description) {
+                return schema.description;
+            }
+            const descriptions = {
+                'bash': 'Execute shell commands in the terminal',
+                'write_code': 'Create or modify code files',
+                'edit': 'Edit existing files with specific changes',
+                'project_setup': 'Set up project structure and dependencies',
+                'picture_generation': 'Generate images using AI',
+                'default': 'Review and modify the parameters before executing this tool.'
+            };
+            return descriptions[toolName] || descriptions.default;
+        }
+
+        function createFormField(param, info, value) {
+            const group = document.createElement('div');
+            group.className = 'form-group';
+
+            const label = document.createElement('label');
+            label.className = 'form-label';
+            label.textContent = param;
+
+            if (info.required) {
+                const required = document.createElement('span');
+                required.className = 'required';
+                required.textContent = '*';
+                label.appendChild(required);
+            } else {
+                const optional = document.createElement('span');
+                optional.className = 'optional';
+                optional.textContent = ' (optional)';
+                label.appendChild(optional);
+            }
+
+            group.appendChild(label);
+
+            let input;
+
+            if (info.enum) {
+                input = document.createElement('select');
+                input.className = 'form-control';
+                if (!info.required) {
+                    const emptyOption = document.createElement('option');
+                    emptyOption.value = '';
+                    emptyOption.textContent = '-- Select --';
+                    input.appendChild(emptyOption);
+                }
+                info.enum.forEach(function(opt) {
+                    const option = document.createElement('option');
+                    option.value = opt;
+                    option.textContent = opt;
+                    if (opt == value) option.selected = true;
+                    input.appendChild(option);
+                });
+            } else if (info.type === 'boolean') {
+                const checkboxGroup = document.createElement('div');
+                checkboxGroup.className = 'checkbox-group';
+                input = document.createElement('input');
+                input.type = 'checkbox';
+                input.checked = value === true || value === 'true';
+                const checkboxLabel = document.createElement('label');
+                checkboxLabel.textContent = 'Enable';
+                checkboxGroup.appendChild(input);
+                checkboxGroup.appendChild(checkboxLabel);
+                group.appendChild(checkboxGroup);
+            } else if (info.type === 'array') {
+                const arrayContainer = document.createElement('div');
+                arrayContainer.className = 'array-input';
+                const tagsContainer = document.createElement('div');
+                tagsContainer.className = 'array-tags';
+                input = document.createElement('input');
+                input.type = 'text';
+                input.className = 'form-control';
+                input.placeholder = 'Type and press Enter to add items';
+                let arrayValue = Array.isArray(value) ? value : (value ? [value] : []);
+                const arrayId = 'array_' + Math.random().toString(36).substr(2, 9);
+                function updateTags() {
+                    tagsContainer.innerHTML = '';
+                    arrayValue.forEach(function(item, index) {
+                        const tag = document.createElement('span');
+                        tag.className = 'array-tag';
+                        tag.innerHTML = escapeHtml(item) + '<span class="remove" onclick="removeArrayItem_' + arrayId + '(' + index + ')">×</span>';
+                        tagsContainer.appendChild(tag);
+                    });
+                }
+                window['removeArrayItem_' + arrayId] = function(index) {
+                    arrayValue.splice(index, 1);
+                    updateTags();
+                };
+                input.addEventListener('keydown', function(e) {
+                    if (e.key === 'Enter' && this.value.trim()) {
+                        e.preventDefault();
+                        arrayValue.push(this.value.trim());
+                        this.value = '';
+                        updateTags();
+                    }
+                });
+                input.getArrayValue = function() { return arrayValue; };
+                updateTags();
+                arrayContainer.appendChild(tagsContainer);
+                arrayContainer.appendChild(input);
+                group.appendChild(arrayContainer);
+            } else if (info.type === 'integer') {
+                input = document.createElement('input');
+                input.type = 'number';
+                input.className = 'form-control';
+                input.value = value || '';
+                input.step = '1';
+            } else {
+                input = document.createElement('textarea');
+                input.className = 'form-control';
+                input.value = value || '';
+                input.rows = info.type === 'string' && (value || '').length > 100 ? 4 : 2;
+            }
+
+            if (input) {
+                input.name = param;
+                if (info.type !== 'boolean' && info.type !== 'array') {
+                    group.appendChild(input);
+                }
+            }
+
+            if (info.description) {
+                const help = document.createElement('div');
+                help.className = 'form-help';
+                help.textContent = info.description;
+                group.appendChild(help);
+            }
+
+            const error = document.createElement('div');
+            error.className = 'form-error';
+            group.appendChild(error);
+
+            return group;
+        }
+
+        function validateForm() {
+            const form = document.getElementById('tool_prompt_form');
+            let isValid = true;
+
+            document.querySelectorAll('.form-control').forEach(function(control) {
+                control.classList.remove('error');
+            });
+            document.querySelectorAll('.form-error').forEach(function(error) {
+                error.style.display = 'none';
+            });
+
+            if (!currentToolData) return false;
+
+            const props = currentToolData.schema?.properties || {};
+            const required = currentToolData.schema?.required || [];
+
+            for (let param in props) {
+                const info = props[param];
+                const isRequired = required.includes(param);
+                const control = form.querySelector('[name="' + param + '"]');
+                if (!control) continue;
+
+                let value;
+                if (control.type === 'checkbox') {
+                    value = control.checked;
+                } else if (control.getArrayValue) {
+                    value = control.getArrayValue();
+                } else {
+                    value = control.value.trim();
+                }
+
+                if (isRequired && (value === '' || value === null || value.length === 0)) {
+                    control.classList.add('error');
+                    const errorDiv = control.closest('.form-group').querySelector('.form-error');
+                    errorDiv.textContent = 'This field is required';
+                    errorDiv.style.display = 'block';
+                    isValid = false;
+                    continue;
+                }
+
+                if (info.type === 'integer' && value !== '' && isNaN(parseInt(value))) {
+                    control.classList.add('error');
+                    const errorDiv = control.closest('.form-group').querySelector('.form-error');
+                    errorDiv.textContent = 'Must be a valid number';
+                    errorDiv.style.display = 'block';
+                    isValid = false;
+                }
+            }
+
+            return isValid;
+        }
+
+        function showToolPrompt(data) {
+            currentToolData = data;
+            const modal = document.getElementById('tool_prompt_modal');
+            const form = document.getElementById('tool_prompt_form');
+            const title = document.getElementById('tool_name_text');
+            const description = document.getElementById('tool_description');
+
+            title.textContent = `Confirm ${data.tool}`;
+            description.textContent = getToolDescription(data.tool, data.schema);
+
+            form.innerHTML = '';
+
+            const props = data.schema?.properties || {};
+            const required = data.schema?.required || [];
+            for (let param in props) {
+                const info = { ...props[param], required: required.includes(param) };
+                const value = data.values?.[param];
+                form.appendChild(createFormField(param, info, value));
+            }
+
+            modal.style.display = 'block';
+        }
+
+        function hideToolPrompt() {
+            document.getElementById('tool_prompt_modal').style.display = 'none';
+            currentToolData = null;
+        }
+
+        function cancelToolCall() {
+            hideToolPrompt();
+            socket.emit('tool_response', { cancelled: true });
+        }
+
+        function executeToolCall() {
+            if (!validateForm()) {
+                return;
+            }
+            const form = document.getElementById('tool_prompt_form');
+            const result = {};
+            const props = currentToolData.schema?.properties || {};
+            for (let param in props) {
+                const info = props[param];
+                const control = form.querySelector('[name="' + param + '"]');
+                if (!control) continue;
+
+                let value = control.value;
+                if (control.type === 'checkbox') {
+                    value = control.checked;
+                } else if (control.getArrayValue) {
+                    value = control.getArrayValue();
+                } else if (info.type === 'integer') {
+                    const parsed = parseInt(value);
+                    if (!isNaN(parsed)) value = parsed;
+                } else if (info.type === 'array' && typeof value === 'string') {
+                    try {
+                        value = JSON.parse(value);
+                    } catch (err) {
+                        value = value.split(',').map(v => v.trim()).filter(v => v);
+                    }
+                }
+                result[param] = value;
+            }
+            socket.emit('tool_response', { input: result });
+        }
+
         function sendMessage() {
             const input = document.getElementById('user_input');
             const message = input.value.trim();
@@ -551,33 +807,6 @@
             updateMainDisplay('<h3>⏹️ Agent Interrupted</h3><p>The agent has been stopped.</p>');
         }
 
-        function showToolPrompt(data) {
-            // Basic tool prompt functionality
-            console.log('Tool prompt:', data);
-            const modal = document.getElementById('tool_prompt_modal');
-            const title = document.getElementById('tool_name_text');
-            const description = document.getElementById('tool_description');
-            
-            title.textContent = `Confirm ${data.tool || 'Tool'}`;
-            description.textContent = data.description || 'Tool requires confirmation';
-            
-            modal.style.display = 'block';
-        }
-
-        function hideToolPrompt() {
-            document.getElementById('tool_prompt_modal').style.display = 'none';
-        }
-
-        function cancelToolCall() {
-            hideToolPrompt();
-            socket.emit('tool_response', {action: 'cancel'});
-        }
-
-        function executeToolCall() {
-            hideToolPrompt();
-            socket.emit('tool_response', {action: 'execute'});
-        }
-
         // Handle Enter key in textarea
         document.getElementById('user_input').addEventListener('keydown', function(e) {
             if (e.key === 'Enter' && !e.shiftKey) {
@@ -588,15 +817,15 @@
 
         // Handle Escape key to close modal
         document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape') {
-                hideToolPrompt();
+            if (e.key === 'Escape' && document.getElementById('tool_prompt_modal').style.display === 'block') {
+                cancelToolCall();
             }
         });
 
         // Handle click outside modal to close
         document.getElementById('tool_prompt_modal').addEventListener('click', function(e) {
             if (e.target === this) {
-                hideToolPrompt();
+                cancelToolCall();
             }
         });
 


### PR DESCRIPTION
## Summary
- Reintroduce editable tool parameter modal in web interface when using manual tool confirmation
- Add comprehensive form generation and validation logic so users can modify arguments before execution

## Testing
- `pytest` *(fails: agent_test.py::test_step_happy, agent_test.py::test_step_no_tool_calls_user_exit, agent_test.py::test_step_no_tool_calls_user_continue)*

------
https://chatgpt.com/codex/tasks/task_e_68917f435e388331846df1713a76134a