### PR TITLE
Restore manual tool parameter editing in web UI

### DIFF
--- a/templates/web_ide.html
+++ b/templates/web_ide.html
@@ -396,14 +396,21 @@
     <div id="tool_prompt_modal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
+                <span class="tool-icon"></span>
                 <h3 id="tool_name_text">Tool Confirmation</h3>
                 <span class="close" onclick="hideToolPrompt()">&times;</span>
             </div>
             <div id="tool_description"></div>
+            <div id="parameter_preview" style="display:none;">
+                <pre id="parameter_preview_content"></pre>
+            </div>
             <form id="tool_prompt_form"></form>
             <div style="margin-top: 20px; text-align: right;">
                 <button onclick="cancelToolCall()" style="margin-right: 10px; background-color: #666;">Cancel</button>
-                <button onclick="executeToolCall()" id="execute_btn">Execute</button>
+                <button onclick="executeToolCall()" id="execute_btn">
+                    <span id="execute_text">Execute</span>
+                    <span id="loading_spinner" style="display:none;">⏳</span>
+                </button>
             </div>
         </div>
     </div>
@@ -412,6 +419,7 @@
         // Initialize the WebSocket connection and UI
         const socket = io();
         let currentTab = 'user';
+        let currentToolData = null;
 
         socket.on('connect', function() {
             console.log('Connected to agent');
@@ -551,21 +559,278 @@
             updateMainDisplay('<h3>⏹️ Agent Interrupted</h3><p>The agent has been stopped.</p>');
         }
 
+        function getToolIcon(toolName) {
+            const icons = {
+                'bash': '💻',
+                'write_code': '📝',
+                'edit': '✏️',
+                'project_setup': '🏗️',
+                'picture_generation': '🎨',
+                'file_operations': '📁',
+                'search': '🔍',
+                'default': '🔧'
+            };
+            return icons[toolName] || icons.default;
+        }
+
+        function getToolDescription(toolName, schema) {
+            if (schema && schema.description) {
+                return schema.description;
+            }
+
+            const descriptions = {
+                'bash': 'Execute shell commands in the terminal',
+                'write_code': 'Create or modify code files',
+                'edit': 'Edit existing files with specific changes',
+                'project_setup': 'Set up project structure and dependencies',
+                'picture_generation': 'Generate images using AI',
+                'default': 'Review and modify the parameters before executing this tool.'
+            };
+            return descriptions[toolName] || descriptions.default;
+        }
+
+        function createFormField(param, info, value) {
+            const group = document.createElement('div');
+            group.className = 'form-group';
+
+            const label = document.createElement('label');
+            label.className = 'form-label';
+            label.textContent = param;
+
+            if (info.required) {
+                const required = document.createElement('span');
+                required.className = 'required';
+                required.textContent = '*';
+                label.appendChild(required);
+            } else {
+                const optional = document.createElement('span');
+                optional.className = 'optional';
+                optional.textContent = ' (optional)';
+                label.appendChild(optional);
+            }
+
+            group.appendChild(label);
+
+            let input;
+
+            if (info.enum) {
+                input = document.createElement('select');
+                input.className = 'form-control';
+
+                if (!info.required) {
+                    const emptyOption = document.createElement('option');
+                    emptyOption.value = '';
+                    emptyOption.textContent = '-- Select --';
+                    input.appendChild(emptyOption);
+                }
+
+                info.enum.forEach(function(opt) {
+                    const option = document.createElement('option');
+                    option.value = opt;
+                    option.textContent = opt;
+                    if (opt == value) option.selected = true;
+                    input.appendChild(option);
+                });
+            } else if (info.type === 'boolean') {
+                const checkboxGroup = document.createElement('div');
+                checkboxGroup.className = 'checkbox-group';
+
+                input = document.createElement('input');
+                input.type = 'checkbox';
+                input.checked = value === true || value === 'true';
+
+                const checkboxLabel = document.createElement('label');
+                checkboxLabel.textContent = 'Enable';
+
+                checkboxGroup.appendChild(input);
+                checkboxGroup.appendChild(checkboxLabel);
+                group.appendChild(checkboxGroup);
+            } else if (info.type === 'array') {
+                const arrayContainer = document.createElement('div');
+                arrayContainer.className = 'array-input';
+
+                const tagsContainer = document.createElement('div');
+                tagsContainer.className = 'array-tags';
+
+                input = document.createElement('input');
+                input.type = 'text';
+                input.className = 'form-control';
+                input.placeholder = 'Type and press Enter to add items';
+
+                let arrayValue = Array.isArray(value) ? value : (value ? [value] : []);
+                const arrayId = 'array_' + Math.random().toString(36).substr(2, 9);
+
+                function updateTags() {
+                    tagsContainer.innerHTML = '';
+                    arrayValue.forEach(function(item, index) {
+                        const tag = document.createElement('span');
+                        tag.className = 'array-tag';
+                        tag.innerHTML = escapeHtml(item) + '<span class="remove" onclick="removeArrayItem_' + arrayId + '(' + index + ')">×</span>';
+                        tagsContainer.appendChild(tag);
+                    });
+                }
+
+                window['removeArrayItem_' + arrayId] = function(index) {
+                    arrayValue.splice(index, 1);
+                    updateTags();
+                };
+
+                input.addEventListener('keydown', function(e) {
+                    if (e.key === 'Enter' && this.value.trim()) {
+                        e.preventDefault();
+                        arrayValue.push(this.value.trim());
+                        this.value = '';
+                        updateTags();
+                    }
+                });
+
+                input.getArrayValue = function() { return arrayValue; };
+
+                updateTags();
+                arrayContainer.appendChild(tagsContainer);
+                arrayContainer.appendChild(input);
+                group.appendChild(arrayContainer);
+            } else if (info.type === 'integer') {
+                input = document.createElement('input');
+                input.type = 'number';
+                input.className = 'form-control';
+                input.value = value || '';
+                input.step = '1';
+            } else {
+                input = document.createElement('textarea');
+                input.className = 'form-control';
+                input.value = value || '';
+                input.rows = info.type === 'string' && (value || '').length > 100 ? 4 : 2;
+            }
+
+            if (input) {
+                input.name = param;
+                if (info.type !== 'boolean' && info.type !== 'array') {
+                    group.appendChild(input);
+                }
+            }
+
+            if (info.description) {
+                const help = document.createElement('div');
+                help.className = 'form-help';
+                help.textContent = info.description;
+                group.appendChild(help);
+            }
+
+            const error = document.createElement('div');
+            error.className = 'form-error';
+            group.appendChild(error);
+
+            return group;
+        }
+
+        function validateForm() {
+            const form = document.getElementById('tool_prompt_form');
+            let isValid = true;
+
+            document.querySelectorAll('.form-control').forEach(function(control) {
+                control.classList.remove('error');
+            });
+            document.querySelectorAll('.form-error').forEach(function(error) {
+                error.style.display = 'none';
+            });
+
+            if (!currentToolData) return false;
+
+            const props = currentToolData.schema?.properties || {};
+            const required = currentToolData.schema?.required || [];
+
+            for (let param in props) {
+                const info = props[param];
+                const isRequired = required.includes(param);
+                const control = form.querySelector('[name="' + param + '"]');
+
+                if (!control) continue;
+
+                let value = control.value;
+                if (control.getArrayValue) {
+                    value = control.getArrayValue();
+                }
+
+                if (isRequired && (!value || (Array.isArray(value) && value.length === 0))) {
+                    control.classList.add('error');
+                    const errorDiv = control.closest('.form-group').querySelector('.form-error');
+                    errorDiv.textContent = 'This field is required';
+                    errorDiv.style.display = 'block';
+                    isValid = false;
+                }
+
+                if (value && info.type === 'integer') {
+                    const numValue = parseInt(value);
+                    if (isNaN(numValue)) {
+                        control.classList.add('error');
+                        const errorDiv = control.closest('.form-group').querySelector('.form-error');
+                        errorDiv.textContent = 'Must be a valid number';
+                        errorDiv.style.display = 'block';
+                        isValid = false;
+                    }
+                }
+            }
+
+            return isValid;
+        }
+
         function showToolPrompt(data) {
-            // Basic tool prompt functionality
-            console.log('Tool prompt:', data);
+            currentToolData = data;
             const modal = document.getElementById('tool_prompt_modal');
+            const form = document.getElementById('tool_prompt_form');
             const title = document.getElementById('tool_name_text');
             const description = document.getElementById('tool_description');
-            
-            title.textContent = `Confirm ${data.tool || 'Tool'}`;
-            description.textContent = data.description || 'Tool requires confirmation';
-            
+            const preview = document.getElementById('parameter_preview');
+            const previewContent = document.getElementById('parameter_preview_content');
+
+            const toolIcon = document.querySelector('.tool-icon');
+            toolIcon.textContent = getToolIcon(data.tool);
+            title.textContent = `Confirm ${data.tool}`;
+            description.textContent = getToolDescription(data.tool, data.schema);
+
+            if (data.values && Object.keys(data.values).length > 0) {
+                previewContent.textContent = JSON.stringify(data.values, null, 2);
+                preview.style.display = 'block';
+            } else {
+                preview.style.display = 'none';
+            }
+
+            form.innerHTML = '';
+            const props = data.schema?.properties || {};
+            const required = data.schema?.required || [];
+
+            for (let param in props) {
+                const info = { ...props[param], required: required.includes(param) };
+                const value = data.values?.[param];
+                const field = createFormField(param, info, value);
+                form.appendChild(field);
+            }
+
+            const executeBtn = document.getElementById('execute_btn');
+            const executeText = document.getElementById('execute_text');
+            const loadingSpinner = document.getElementById('loading_spinner');
+
+            executeBtn.disabled = false;
+            executeText.style.display = 'inline';
+            loadingSpinner.style.display = 'none';
+
             modal.style.display = 'block';
+
+            setTimeout(() => {
+                const focusable = form.querySelectorAll('input:not([type=hidden]):not([disabled]), select:not([disabled]), textarea:not([disabled])');
+                for (const el of focusable) {
+                    if (el.offsetParent !== null) {
+                        el.focus();
+                        break;
+                    }
+                }
+            }, 100);
         }
 
         function hideToolPrompt() {
             document.getElementById('tool_prompt_modal').style.display = 'none';
+            currentToolData = null;
         }
 
         function cancelToolCall() {
@@ -574,8 +839,49 @@
         }
 
         function executeToolCall() {
-            hideToolPrompt();
-            socket.emit('tool_response', {action: 'execute'});
+            if (!validateForm()) {
+                return;
+            }
+
+            const form = document.getElementById('tool_prompt_form');
+            const executeBtn = document.getElementById('execute_btn');
+            const executeText = document.getElementById('execute_text');
+            const loadingSpinner = document.getElementById('loading_spinner');
+
+            executeBtn.disabled = true;
+            executeText.style.display = 'none';
+            loadingSpinner.style.display = 'inline-block';
+
+            const result = {};
+            const props = currentToolData.schema?.properties || {};
+
+            for (let param in props) {
+                const info = props[param];
+                const control = form.querySelector('[name="' + param + '"]');
+
+                if (!control) continue;
+
+                let value = control.value;
+
+                if (control.type === 'checkbox') {
+                    value = control.checked;
+                } else if (control.getArrayValue) {
+                    value = control.getArrayValue();
+                } else if (info.type === 'integer') {
+                    const parsed = parseInt(value);
+                    if (!isNaN(parsed)) value = parsed;
+                } else if (info.type === 'array' && typeof value === 'string') {
+                    try {
+                        value = JSON.parse(value);
+                    } catch (err) {
+                        value = value.split(',').map(v => v.trim()).filter(v => v);
+                    }
+                }
+
+                result[param] = value;
+            }
+
+            socket.emit('tool_response', { input: result });
         }
 
         // Handle Enter key in textarea


### PR DESCRIPTION
## Summary
- Restore full manual tool parameter editing modal in web IDE, including editable fields, icon, parameter preview, and execution spinner

## Testing
- `pytest` *(fails: EditTool, WriteCodeTool, command converter, repo browser, OpenInterpreterTool tests)*

------
https://chatgpt.com/codex/tasks/task_e_68917f435e388331846df1713a76134a

## Summary by Sourcery

Restore full manual editing of tool parameters in the web IDE by revamping the tool confirmation modal to dynamically generate and validate input fields based on tool schemas.

New Features:
- Add dynamic form generation for tool parameters supporting enums, booleans, arrays, integers, and multi-line inputs
- Display a preview of existing parameter values and show tool-specific icons and descriptions in the modal header
- Show an execution spinner and disable the execute button during tool invocation
- Automatically focus the first available form field when the modal opens

Enhancements:
- Implement client-side validation for required fields and integer type constraints
- Emit structured tool_response payload containing user-edited parameter values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool confirmation modal with dynamic icons and a parameter preview section displaying input values.
  * Modal form now adapts to various input types (dropdowns, checkboxes, tag-style inputs, number fields, textareas) based on tool requirements.
  * Inline validation and error messages for required fields and input types.
  * Improved UI feedback with loading spinner and clearer form field indicators.

* **Bug Fixes**
  * Prevents form submission with invalid or missing required inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->