### PR TITLE
fix: Restore tool parameter editing modal

### DIFF
--- a/templates/web_ide.html
+++ b/templates/web_ide.html
@@ -552,15 +552,67 @@
         }
 
         function showToolPrompt(data) {
-            // Basic tool prompt functionality
             console.log('Tool prompt:', data);
             const modal = document.getElementById('tool_prompt_modal');
             const title = document.getElementById('tool_name_text');
             const description = document.getElementById('tool_description');
-            
+            const form = document.getElementById('tool_prompt_form');
+
             title.textContent = `Confirm ${data.tool || 'Tool'}`;
-            description.textContent = data.description || 'Tool requires confirmation';
-            
+            description.innerHTML = data.schema.description || 'Tool requires confirmation';
+            form.innerHTML = ''; // Clear previous form content
+
+            const properties = data.schema.properties || {};
+            for (const param in properties) {
+                const info = properties[param];
+                const value = data.values ? data.values[param] : '';
+
+                const formGroup = document.createElement('div');
+                formGroup.className = 'form-group';
+
+                const label = document.createElement('label');
+                label.htmlFor = param;
+                label.textContent = param;
+                formGroup.appendChild(label);
+
+                if (info.enum) {
+                    const select = document.createElement('select');
+                    select.name = param;
+                    select.id = param;
+                    info.enum.forEach(opt => {
+                        const option = document.createElement('option');
+                        option.value = opt;
+                        option.textContent = opt;
+                        if (opt === value) {
+                            option.selected = true;
+                        }
+                        select.appendChild(option);
+                    });
+                    formGroup.appendChild(select);
+                } else if (info.type === 'array') {
+                    const textarea = document.createElement('textarea');
+                    textarea.name = param;
+                    textarea.id = param;
+                    textarea.placeholder = 'Enter JSON array or comma-separated values';
+                    textarea.value = Array.isArray(value) ? JSON.stringify(value, null, 2) : value;
+                    formGroup.appendChild(textarea);
+                } else if (info.type === 'string' && info.format === 'long-text') {
+                    const textarea = document.createElement('textarea');
+                    textarea.name = param;
+                    textarea.id = param;
+                    textarea.rows = 5;
+                    textarea.value = value;
+                    formGroup.appendChild(textarea);
+                } else {
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.name = param;
+                    input.id = param;
+                    input.value = value;
+                    formGroup.appendChild(input);
+                }
+                form.appendChild(formGroup);
+            }
             modal.style.display = 'block';
         }
 
@@ -574,8 +626,18 @@
         }
 
         function executeToolCall() {
+            const form = document.getElementById('tool_prompt_form');
+            const inputs = form.querySelectorAll('input, textarea, select');
+            const params = {};
+            inputs.forEach(input => {
+                if (input.type === 'checkbox') {
+                    params[input.name] = input.checked;
+                } else {
+                    params[input.name] = input.value;
+                }
+            });
             hideToolPrompt();
-            socket.emit('tool_response', {action: 'execute'});
+            socket.emit('tool_response', {action: 'execute', input: params});
         }
 
         // Handle Enter key in textarea


### PR DESCRIPTION
The `showToolPrompt` JavaScript function in `templates/web_ide.html` was not correctly generating the form for tool parameters. It was only showing the tool name and a confirmation button.

This change updates `showToolPrompt` to dynamically generate a form with input fields for each tool parameter, based on the provided schema. The `executeToolCall` function has also been updated to collect the edited parameters from the form and send them back to the server.

## Summary by Sourcery

Restore the tool parameter editing modal by dynamically generating input fields from the tool schema and include edited values when executing the tool.

Bug Fixes:
- Fix showToolPrompt to clear and populate the form with tool parameters instead of only showing the name and confirmation button

Enhancements:
- Generate appropriate input, textarea, or select elements for each schema property based on its type and format
- Update executeToolCall to collect all form inputs and emit them with the execute action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool confirmation prompts now display dynamic forms based on the tool’s schema, allowing users to input required parameters directly.
* **Improvements**
  * Enhanced user experience by collecting and submitting input values from the dynamically generated forms during tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->