### PR TITLE
Edit files using llm

### DIFF
--- a/config.py
+++ b/config.py
@@ -194,6 +194,9 @@ def write_constants_to_file():
         "MAX_SUMMARY_TOKENS": MAX_SUMMARY_TOKENS,
         "PROMPT_NAME": PROMPT_NAME if PROMPT_NAME else "",
         "TASK": "NOT YET CREATED", # Default task, can be updated by set_constant
+        # Edit tool LLM settings
+        "EDIT_WITH_LLM": False,
+        "EDIT_LLM_MODEL": str(MAIN_MODEL),
     }
     # Ensure CACHE_DIR exists before writing
     CACHE_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Introduce an optional LLM-backed mode for `str_replace` and `insert` in the edit tool, allowing LLMs to perform edits by returning the full updated file, controlled by new `EDIT_WITH_LLM` and `EDIT_LLM_MODEL` config flags.

---
<a href="https://cursor.com/background-agent?bcId=bc-96832e7f-8955-4e75-92ee-6ed1350a93d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96832e7f-8955-4e75-92ee-6ed1350a93d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

