### PR TITLE
Fix local message display

### DIFF
--- a/MESSAGE_DISPLAY_FIX.md
+++ b/MESSAGE_DISPLAY_FIX.md
@@ -1,0 +1,102 @@
+# Message Display Fix Documentation
+
+## Problem
+The application had an issue where console-style messages and user messages were not displaying when running locally, although they worked correctly on Heroku.
+
+## Root Cause Analysis
+
+The issue was caused by several factors:
+
+1. **Different Server Configurations**: Heroku uses Gunicorn with eventlet worker which properly handles WebSocket connections, while the local development server was using Flask's built-in server with different threading behavior.
+
+2. **WebSocket Timing Issues**: Messages were being added to the display before the WebSocket client was fully connected and ready to receive them.
+
+3. **Missing Error Handling**: The WebSocket emit operations didn't have proper error handling, causing silent failures when clients weren't connected.
+
+4. **Missing Method**: The code referenced a non-existent `_emit_file_tree_update` method which could cause errors.
+
+## Solutions Implemented
+
+### 1. Enhanced Error Handling in WebUI
+- Added try-except blocks around all `socketio.emit()` calls to handle connection failures gracefully
+- Added detailed logging to track message flow and identify issues
+- Messages are always stored in arrays regardless of WebSocket state, ensuring they can be retrieved via the `/messages` endpoint
+
+### 2. Fixed WebSocket Connection Synchronization
+- Modified the `connect` event handler to always send all existing messages when a client connects
+- This ensures that even if messages were added before the client connected, they will be received
+
+### 3. Created Eventlet-Based Local Runner
+- Created `run_local.py` which uses eventlet (same as production) for proper WebSocket support
+- This ensures the local environment behaves similarly to the Heroku deployment
+
+### 4. Fixed Code Issues
+- Commented out the call to the non-existent `_emit_file_tree_update` method
+- Added proper error handling for broadcast operations
+
+## How to Use
+
+### For Local Development (Recommended)
+```bash
+# Use the new eventlet-based runner for better WebSocket support
+python run_local.py --port 5002
+
+# Or with manual tool confirmation
+python run_local.py --port 5002 --manual-tools
+
+# To prevent browser from opening automatically
+python run_local.py --port 5002 --no-browser
+```
+
+### Original Method (Still Available)
+```bash
+# Original CLI interface
+python run.py web --port 5002
+```
+
+## Key Changes Made
+
+### `/workspace/utils/web_ui.py`
+1. Added error handling to `add_message()` method
+2. Added error handling to `broadcast_update()` method  
+3. Enhanced `connect` event handler to always send existing messages
+4. Fixed reference to non-existent method
+5. Added detailed logging throughout
+
+### `/workspace/run_local.py` (New File)
+- Created a new runner that uses eventlet's WSGI server
+- Ensures proper WebSocket support in local development
+- Matches production environment behavior
+
+## Testing Recommendations
+
+1. Start the server using `python run_local.py`
+2. Open the browser and select/create a task
+3. Verify that:
+   - User messages appear in the left pane
+   - Console messages appear in the main pane
+   - Tool execution results are displayed
+   - Messages persist across page refreshes
+
+## Technical Details
+
+### Message Flow
+1. Agent calls `display.add_message(type, content)`
+2. Message is stored in the appropriate array (`user_messages`, `assistant_messages`, or `tool_results`)
+3. Message is emitted via WebSocket to all connected clients
+4. If WebSocket fails, message is still stored and can be retrieved via `/messages` endpoint
+5. When a new client connects, all existing messages are sent immediately
+
+### WebSocket Events
+- `connect`: Sends all existing messages to newly connected client
+- `update`: Broadcasts message updates to all clients
+- `user_message`, `assistant_message`, `tool_result`: Specific message type events
+
+## Future Improvements
+
+Consider implementing:
+1. Message persistence in a database for better reliability
+2. Message queue system for guaranteed delivery
+3. Reconnection logic with message synchronization
+4. Rate limiting for message broadcasts
+5. Compression for large message payloads

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""
+Local development runner with proper eventlet support for WebSocket connections.
+This ensures that the local environment behaves similarly to the Heroku deployment.
+"""
+
+import eventlet
+# Monkey patch standard library to work with eventlet
+eventlet.monkey_patch()
+
+import asyncio
+import click
+import webbrowser
+import socket
+from dotenv import load_dotenv
+
+from agent import Agent
+from utils.web_ui import WebUI
+from utils.file_logger import archive_logs
+
+async def run_agent_async(task, display, manual_tools=False):
+    """Asynchronously runs the agent with a given task and display."""
+    output = f"The users original task is: {task}\n"
+    display.add_message("user", output)
+    output = "# Refining Now..."
+    display.add_message("user", output)
+    agent = Agent(task=task, display=display, manual_tool_confirmation=manual_tools)
+    await agent._revise_and_save_task(agent.task)
+    agent.messages.append({"role": "user", "content": agent.task})
+    await sampling_loop(agent=agent)
+
+async def sampling_loop(agent: Agent):
+    """Main loop for the agent."""
+    running = True
+    while running:
+        running = await agent.step()
+
+@click.command()
+@click.option('--port', default=5002, help='Port to run the web server on.')
+@click.option('--manual-tools', is_flag=True, help='Confirm tool parameters before execution')
+@click.option('--no-browser', is_flag=True, help='Do not open browser automatically')
+def main(port, manual_tools, no_browser):
+    """Run the agent with a web interface using eventlet for proper WebSocket support."""
+    load_dotenv()
+    archive_logs()
+    
+    print("🚀 Starting Slazy Agent with eventlet support...")
+    
+    display = WebUI(lambda task, disp: run_agent_async(task, disp, manual_tools))
+
+    # Determine the local IP address
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("10.255.255.255", 1))
+            host_ip = s.getsockname()[0]
+    except Exception:
+        host_ip = "localhost"
+
+    url = f"http://{host_ip}:{port}"
+    print(f"✅ Web server starting on port {port}")
+    print(f"📍 Local URL: http://localhost:{port}")
+    print(f"📍 Network URL: {url}")
+    
+    if not no_browser:
+        print("🌐 Opening browser...")
+        webbrowser.open(f"http://localhost:{port}")
+    
+    print("⏳ Waiting for user to start a task from the web interface...")
+    print("💡 Tip: If messages aren't showing, try refreshing the page after starting a task.")
+    
+    # Use eventlet's wsgi server for better WebSocket support
+    import socketio
+    import eventlet.wsgi
+    
+    # Get the underlying SocketIO server
+    sio_server = display.socketio.server
+    
+    # Run with eventlet's WSGI server (similar to production)
+    eventlet.wsgi.server(
+        eventlet.listen(('0.0.0.0', port)),
+        display.app,
+        log_output=False
+    )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes local display of console and user messages by improving WebSocket synchronization and aligning the local server configuration with production.

The issue was caused by differences in server configurations between local development (Flask's built-in server) and Heroku (Gunicorn with eventlet), leading to WebSocket timing issues where messages were emitted before clients were ready, and missing error handling for these operations. This PR introduces an `eventlet`-based local runner, enhances the WebUI with robust error handling for WebSocket emissions, and ensures all existing messages are sent to clients upon connection.

---
<a href="https://cursor.com/background-agent?bcId=bc-e975f6eb-8691-4c62-9eeb-07cd22debb8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e975f6eb-8691-4c62-9eeb-07cd22debb8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

