### PR TITLE
Fix local message display

### DIFF
--- a/utils/web_ui.py
+++ b/utils/web_ui.py
@@ -497,7 +497,7 @@ class WebUI:
         if msg_type == "user":
             self.user_messages.append(content)
             # Also emit to file browser
-            self.socketio.emit("user_message", {"content": content})
+            self.socketio.emit("user_message", {"content": content}, broadcast=True)
         elif msg_type == "assistant":
             self.assistant_messages.append(content)
             # Also emit to file browser
@@ -532,6 +532,7 @@ class WebUI:
         self.socketio.emit(
             "update",
             data,
+            broadcast=True,
         )
         logging.info("Update broadcast completed")
 


### PR DESCRIPTION
Add `broadcast=True` to Socket.IO emits to ensure console and user messages display locally.

Locally, messages were not appearing because Socket.IO events emitted by the Python backend weren’t marked for broadcast, causing them to only reach the sending thread or not at all from background tasks. This change ensures all connected local clients receive `user_message` and `update` events, mirroring Heroku's behavior with Redis message queuing.

---
<a href="https://cursor.com/background-agent?bcId=bc-79b9a391-6260-494e-a1a4-f6e3bf03cb1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79b9a391-6260-494e-a1a4-f6e3bf03cb1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

