### PR TITLE
Remove skeleton stage from write_code workflow

### DIFF
--- a/tests/tools/test_write_code.py
+++ b/tests/tools/test_write_code.py
@@ -381,13 +381,13 @@ Some additional text.
             calls = mock_display.add_message.call_args_list
             assert len(calls) > 0
             
-            # Check for skeleton generation messages
-            skeleton_messages = [call for call in calls if "skeleton" in str(call).lower()]
-            assert len(skeleton_messages) > 0
-            
-            # Check for code generation messages
-            code_messages = [call for call in calls if "generating" in str(call).lower()]
-            assert len(code_messages) > 0
+            # Check for code generation start messages
+            code_start_messages = [call for call in calls if "generate_code" in str(call).lower()]
+            assert len(code_start_messages) > 0
+
+            # Check for file write messages
+            write_messages = [call for call in calls if "write_file" in str(call).lower()]
+            assert len(write_messages) > 0
 
     @pytest.mark.asyncio
     async def test_llm_response_error_handling(self, write_code_tool: WriteCodeTool):


### PR DESCRIPTION
## Summary
- remove the skeleton generation pass from the write_code tool so code is generated directly
- refresh the system prompt used for code generation to drop skeleton references
- update the write_code tool tests to assert the new display output

## Testing
- ⚠️ `PYTHONPATH=. pytest tests/tools/test_write_code.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68cf5864d9188331a3591b640e68f146

## Summary by Sourcery

Remove the intermediate skeleton generation phase from the write_code tool and streamline code generation to use only descriptions and import lists

Enhancements:
- Bypass skeleton generation and related methods so code is produced directly based on descriptions and imports
- Simplify system and user code prompts by removing all skeleton-oriented instructions
- Update error handling to log failures with code descriptions instead of skeleton placeholders

Documentation:
- Refresh tool description and system prompts to drop all skeleton references

Tests:
- Revise write_code tool tests to assert code generation start and file write messages instead of skeleton messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined code generation by removing the skeleton phase; generation now runs directly, improving speed and simplifying flow.
  - Updated runtime messages to clearly indicate "generate_code" and "write_file" stages for better progress visibility.

- Tests
  - Updated integration checks to validate the new progress messages and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->